### PR TITLE
Get non-prerelease versions from main as 42.42.*

### DIFF
--- a/src/Directory.props
+++ b/src/Directory.props
@@ -4,6 +4,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Devlooped.OpenAI</RootNamespace>
     <UserSecretsId>94e34f89-74fd-421f-838e-ecc8e06bc1a3</UserSecretsId>
+    <!-- Clear suffix to get clean 42.42.* versions from main for easier install/update -->
+    <VersionSuffix Condition="$(VersionSuffix) == 'main'"></VersionSuffix>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Easier to install, and the numbering is fine since it requires an explicit source.