### PR TITLE
Rename from openai > oai to avoid conflict with pip openai

### DIFF
--- a/src/dotnet-openai/auth-login.md
+++ b/src/dotnet-openai/auth-login.md
@@ -1,5 +1,5 @@
 ﻿```shell
-> openai auth login --help
+> oai auth login --help
 DESCRIPTION:
 Authenticate to OpenAI. 
 
@@ -8,16 +8,16 @@ Supports API key autentication using the Git Credential Manager for storage.
 Switch easily between keys by just specifying the project name after initial 
 login with `--with-token`.
 
-Alternatively, openai will use the authentication token found in environment 
+Alternatively, oai will use the authentication token found in environment 
 variables 
 with the name `OPENAI_API_KEY`.
 This method is most suitable for "headless" use such as in automation.
 
-For example, to use openai in GitHub Actions, add `OPENAI_API_KEY: ${{ 
+For example, to use oai in GitHub Actions, add `OPENAI_API_KEY: ${{ 
 secrets.OPENAI_API_KEY }}` to "env".
 
 USAGE:
-    openai auth login <project> [OPTIONS]
+    oai auth login <project> [OPTIONS]
 
 ARGUMENTS:
     <project>    OpenAI project the API key belongs to

--- a/src/dotnet-openai/auth-logout.md
+++ b/src/dotnet-openai/auth-logout.md
@@ -1,10 +1,10 @@
 ﻿```shell
-> openai auth logout --help
+> oai auth logout --help
 DESCRIPTION:
 Log out of api.openai.com
 
 USAGE:
-    openai auth logout [OPTIONS]
+    oai auth logout [OPTIONS]
 
 OPTIONS:
     -h, --help    Prints help information

--- a/src/dotnet-openai/auth-status.md
+++ b/src/dotnet-openai/auth-status.md
@@ -1,7 +1,7 @@
 ﻿```shell
-> openai auth status --help
+> oai auth status --help
 USAGE:
-    openai auth status [OPTIONS]
+    oai auth status [OPTIONS]
 
 OPTIONS:
     -h, --help          Prints help information

--- a/src/dotnet-openai/auth.md
+++ b/src/dotnet-openai/auth.md
@@ -1,7 +1,7 @@
 ﻿```shell
-> openai auth --help
+> oai auth --help
 USAGE:
-    openai auth [OPTIONS] <COMMAND>
+    oai auth [OPTIONS] <COMMAND>
 
 OPTIONS:
     -h, --help    Prints help information
@@ -15,15 +15,15 @@ COMMANDS:
                        Switch easily between keys by just specifying the project
                        name after initial login with `--with-token`.            
                                                                                 
-                       Alternatively, openai will use the authentication token  
+                       Alternatively, oai will use the authentication token     
                        found in environment variables                           
                        with the name `OPENAI_API_KEY`.                          
                        This method is most suitable for "headless" use such as  
                        in automation.                                           
                                                                                 
-                       For example, to use openai in GitHub Actions, add        
+                       For example, to use oai in GitHub Actions, add           
                        `OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}` to "env" 
     logout             Log out of api.openai.com                                
     status                                                                      
-    token              Print the auth token openai is configured to use         
+    token              Print the auth token oai is configured to use            
 ```

--- a/src/dotnet-openai/dotnet-openai.csproj
+++ b/src/dotnet-openai/dotnet-openai.csproj
@@ -5,8 +5,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageId>dotnet-openai</PackageId>
-    <Description>Normas argentinas en formato abierto</Description>
-    <ToolCommandName>openai</ToolCommandName>
+    <Description>An OpenAI CLI</Description>
+    <ToolCommandName>oai</ToolCommandName>
     <PackageTags>openai dotnet-tool</PackageTags>
   </PropertyGroup>
 

--- a/src/dotnet-openai/help.md
+++ b/src/dotnet-openai/help.md
@@ -1,7 +1,7 @@
 ﻿```shell
-> openai --help
+> oai --help
 USAGE:
-    openai [OPTIONS] <COMMAND>
+    oai [OPTIONS] <COMMAND>
 
 OPTIONS:
     -h, --help    Prints help information


### PR DESCRIPTION
If you have used `pip install openai`, it might take precedence over dotnet global tools. So we just make our name unique, and shorter, which seems better anyway.