### PR TITLE
Rename back to openai, improve docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,15 @@ COMMANDS:
 ```
 
 <!-- src/dotnet-openai/Docs/help.md -->
+
+## Authentication
+
+Authentication is managed for you by the CLI, using the [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) 
+as the cross-platform secure storage for your API key(s). You can login multiple project/key 
+combination and then just change the active one without ever re-entering the keys.
+
+See [authentication](https://platform.openai.com/docs/api-reference/authentication) for more details.
+
 <!-- include src/dotnet-openai/Docs/auth.md -->
 ```shell
 > oai auth --help
@@ -118,6 +127,11 @@ OPTIONS:
 ```
 
 <!-- src/dotnet-openai/Docs/auth-status.md -->
+
+## Files
+
+Implements the [Files API](https://platform.openai.com/docs/api-reference/files).
+
 <!-- include src/dotnet-openai/Docs/file.md -->
 ```shell
 > oai file --help
@@ -140,6 +154,11 @@ COMMANDS:
 ```
 
 <!-- src/dotnet-openai/Docs/file.md -->
+
+## Vector Stores
+
+Implements the [Vector Stores API](https://platform.openai.com/docs/api-reference/vector-stores).
+
 <!-- include src/dotnet-openai/Docs/vector.md -->
 <!-- include src/dotnet-openai/Docs/vector-file.md -->
 

--- a/src/dotnet-openai/Docs/auth-login.md
+++ b/src/dotnet-openai/Docs/auth-login.md
@@ -1,5 +1,5 @@
 ﻿```shell
-> oai auth login --help
+> openai auth login --help
 DESCRIPTION:
 Authenticate to OpenAI. 
 
@@ -8,15 +8,15 @@ Supports API key autentication using the Git Credential Manager for storage.
 Switch easily between keys by just specifying the project name after initial 
 login with `--with-token`.
 
-Alternatively, oai will use the authentication token found in environment 
+Alternatively, openai will use the authentication token found in environment 
 variables with the name `OPENAI_API_KEY`.
 This method is most suitable for "headless" use such as in automation.
 
-For example, to use oai in GitHub Actions, add `OPENAI_API_KEY: ${{ 
+For example, to use openai in GitHub Actions, add `OPENAI_API_KEY: ${{ 
 secrets.OPENAI_API_KEY }}` to "env".
 
 USAGE:
-    oai auth login <project> [OPTIONS]
+    openai auth login <project> [OPTIONS]
 
 ARGUMENTS:
     <project>    OpenAI project the API key belongs to

--- a/src/dotnet-openai/Docs/auth-logout.md
+++ b/src/dotnet-openai/Docs/auth-logout.md
@@ -1,10 +1,10 @@
 ﻿```shell
-> oai auth logout --help
+> openai auth logout --help
 DESCRIPTION:
 Log out of api.openai.com
 
 USAGE:
-    oai auth logout [OPTIONS]
+    openai auth logout [OPTIONS]
 
 OPTIONS:
     -h, --help    Prints help information

--- a/src/dotnet-openai/Docs/auth-status.md
+++ b/src/dotnet-openai/Docs/auth-status.md
@@ -1,7 +1,7 @@
 ﻿```shell
-> oai auth status --help
+> openai auth status --help
 USAGE:
-    oai auth status [OPTIONS]
+    openai auth status [OPTIONS]
 
 OPTIONS:
     -h, --help          Prints help information

--- a/src/dotnet-openai/Docs/auth.md
+++ b/src/dotnet-openai/Docs/auth.md
@@ -1,7 +1,7 @@
 ﻿```shell
-> oai auth --help
+> openai auth --help
 USAGE:
-    oai auth [OPTIONS] <COMMAND>
+    openai auth [OPTIONS] <COMMAND>
 
 OPTIONS:
     -h, --help    Prints help information
@@ -15,15 +15,15 @@ COMMANDS:
                        Switch easily between keys by just specifying the project
                        name after initial login with `--with-token`.            
                                                                                 
-                       Alternatively, oai will use the authentication token     
+                       Alternatively, openai will use the authentication token  
                        found in environment variables with the name             
                        `OPENAI_API_KEY`.                                        
                        This method is most suitable for "headless" use such as  
                        in automation.                                           
                                                                                 
-                       For example, to use oai in GitHub Actions, add           
+                       For example, to use openai in GitHub Actions, add        
                        `OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}` to "env" 
     logout             Log out of api.openai.com                                
     status                                                                      
-    token              Print the auth token oai is configured to use            
+    token              Print the auth token openai is configured to use         
 ```

--- a/src/dotnet-openai/Docs/file.md
+++ b/src/dotnet-openai/Docs/file.md
@@ -1,12 +1,13 @@
 ﻿```shell
-> oai file --help
+> openai file --help
 USAGE:
-    oai file [OPTIONS] <COMMAND>
+    openai file [OPTIONS] <COMMAND>
 
 EXAMPLES:
-    oai file list --jq '.[].id'
-    oai file list --jq ".[] | { id: .id, name: .filename, purpose: .purpose }"
-    oai file list --jq ".[] | select(.sizeInBytes > 100000) | .id"
+    openai file list --jq '.[].id'
+    openai file list --jq ".[] | { id: .id, name: .filename, purpose: .purpose 
+}"
+    openai file list --jq ".[] | select(.sizeInBytes > 100000) | .id"
 
 OPTIONS:
     -h, --help    Prints help information

--- a/src/dotnet-openai/Docs/help.md
+++ b/src/dotnet-openai/Docs/help.md
@@ -1,14 +1,16 @@
 ﻿```shell
-> oai --help
+> openai --help
 USAGE:
-    oai [OPTIONS] <COMMAND>
+    openai [OPTIONS] <COMMAND>
 
 EXAMPLES:
-    oai file list --jq '.[].id'
-    oai file list --jq ".[] | { id: .id, name: .filename, purpose: .purpose }"
-    oai file list --jq ".[] | select(.sizeInBytes > 100000) | .id"
-    oai vector create --name my-store --meta 'key1=value1' --meta 'key2=value'
-    oai vector create --name with-files --file asdf123 --file qwer456
+    openai file list --jq '.[].id'
+    openai file list --jq ".[] | { id: .id, name: .filename, purpose: .purpose 
+}"
+    openai file list --jq ".[] | select(.sizeInBytes > 100000) | .id"
+    openai vector create --name my-store --meta 'key1=value1' --meta 
+'key2=value'
+    openai vector create --name with-files --file asdf123 --file qwer456
 
 OPTIONS:
     -h, --help    Prints help information

--- a/src/dotnet-openai/Docs/vector-file.md
+++ b/src/dotnet-openai/Docs/vector-file.md
@@ -1,10 +1,10 @@
 ﻿```shell
-> oai vector file --help
+> openai vector file --help
 DESCRIPTION:
 Vector store files operations
 
 USAGE:
-    oai vector file [OPTIONS] <COMMAND>
+    openai vector file [OPTIONS] <COMMAND>
 
 OPTIONS:
     -h, --help    Prints help information

--- a/src/dotnet-openai/Docs/vector.md
+++ b/src/dotnet-openai/Docs/vector.md
@@ -1,11 +1,12 @@
 ﻿```shell
-> oai vector --help
+> openai vector --help
 USAGE:
-    oai vector [OPTIONS] <COMMAND>
+    openai vector [OPTIONS] <COMMAND>
 
 EXAMPLES:
-    oai vector create --name my-store --meta 'key1=value1' --meta 'key2=value'
-    oai vector create --name with-files --file asdf123 --file qwer456
+    openai vector create --name my-store --meta 'key1=value1' --meta 
+'key2=value'
+    openai vector create --name with-files --file asdf123 --file qwer456
 
 OPTIONS:
     -h, --help    Prints help information

--- a/src/dotnet-openai/dotnet-openai.csproj
+++ b/src/dotnet-openai/dotnet-openai.csproj
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <PackageId>dotnet-openai</PackageId>
     <Description>An OpenAI CLI</Description>
-    <ToolCommandName>oai</ToolCommandName>
+    <ToolCommandName>openai</ToolCommandName>
     <PackageTags>openai dotnet-tool</PackageTags>
 
     <BuildDate>$([System.DateTime]::Now.ToString("yyyy-MM-dd"))</BuildDate>


### PR DESCRIPTION
It's easy to just set the dotnet tools path to be preferred to the python scripts one, therefore resolving the potential conflict with pip install openai.