### PR TITLE
Don't check for updates when running debug builds

### DIFF
--- a/src/dotnet-openai/Program.cs
+++ b/src/dotnet-openai/Program.cs
@@ -40,9 +40,7 @@ app.Configure(config => config.SetApplicationName(ThisAssembly.Project.ToolComma
 if (args.Contains("--version"))
 {
     app.ShowVersion();
-#if DEBUG
     await app.ShowUpdatesAsync(args);
-#endif
     return 0;
 }
 


### PR DESCRIPTION
This is the default for local F5, so no need ot slow down the run even when showing --version.