### PR TITLE
Add support for setting file attributes in vector stores

### DIFF
--- a/src/dotnet-openai/Vectors/FileAddCommand.cs
+++ b/src/dotnet-openai/Vectors/FileAddCommand.cs
@@ -1,19 +1,74 @@
-﻿using System.ComponentModel;
-using System.Threading.Tasks;
+﻿using System.ClientModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text.Json;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
+using static Devlooped.OpenAI.Vectors.FileAddCommand;
 
 namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("Add file to vector store")]
-class FileAddCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileCommandSettings>
+class FileAddCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<FileAddCommandSettings>
 {
-    public override int Execute(CommandContext context, FileCommandSettings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, FileAddCommandSettings settings)
     {
-        var response = oai.GetVectorStoreClient().AddFileToVectorStore(settings.StoreId, settings.FileId, true, cts.Token);
+        var message = oai.Pipeline.CreateMessage();
 
-        return console.RenderJson(response.Value, settings, cts.Token);
+        var attributes = new Dictionary<string, object>();
+        foreach (var item in settings.Attributes)
+        {
+            var parts = item.Split(['='], 2);
+            if (parts.Length == 2)
+            {
+                var key = parts[0].Trim();
+                var value = parts[1].Trim();
+                if (double.TryParse(value, out var number))
+                    attributes[key] = number;
+                else if (bool.TryParse(value, out var boolean))
+                    attributes[key] = boolean;
+                else
+                    attributes[key] = value;
+            }
+        }
+
+        message.Request.Method = "POST";
+        message.Request.Uri = new Uri($"https://api.openai.com/v1/vector_stores/{settings.StoreId}/files");
+        message.Request.Headers.Add("OpenAI-Beta", "assistants=v2");
+        var request = JsonSerializer.Serialize(new { file_id = settings.FileId, attributes });
+        message.Request.Content = BinaryContent.Create(BinaryData.FromString(request));
+
+        await oai.Pipeline.SendAsync(message);
+        Debug.Assert(message.Response != null);
+        var vectors = oai.GetVectorStoreClient();
+
+        var response = await vectors.GetFileAssociationAsync(settings.StoreId, settings.FileId, cts.Token);
+        if (response.Value is null)
+        {
+            console.MarkupLine($":cross_mark: Failed to add file to vector store");
+            return -1;
+        }
+
+        while (response.Value.Status == global::OpenAI.VectorStores.VectorStoreFileAssociationStatus.InProgress)
+        {
+            await Task.Delay(200, cts.Token);
+            response = await vectors.GetFileAssociationAsync(settings.StoreId, settings.FileId, cts.Token);
+            if (response.Value is null)
+            {
+                console.MarkupLine($":cross_mark: Failed to add file to vector store");
+                return -1;
+            }
+        }
+
+        return console.RenderJson(response.GetRawResponse().Content.ToString(), settings.JQ, settings.Monochrome, cts.Token);
+    }
+
+    public class FileAddCommandSettings : FileCommandSettings
+    {
+        [Description("Attributes to add to the vector file as KEY=VALUE")]
+        [CommandOption("-a|--attribute")]
+        public string[] Attributes { get; set; } = [];
     }
 }


### PR DESCRIPTION
The official OpenAI API for .NET does not support this, so we resort to the lower-level HTTP API to achieve this.

In order to get parity with the rendering on the output for both listing and adding, we also switch to rendering raw responses. We should do the same for all the other APIs, since the documented JSON payloads will otherwise not match what we render.