### PR TITLE
File metadata, lists filtering and proper JSON output

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,8 @@ COMMANDS:
 
 <!-- src/dotnet-openai/Docs/file.md -->
 
+<!-- include src/dotnet-openai/Docs/file-list.md -->
+
 ## Vector Stores
 
 Implements the [Vector Stores API](https://platform.openai.com/docs/api-reference/vector-stores).
@@ -213,6 +215,8 @@ COMMANDS:
 ```
 
 <!-- src/dotnet-openai/Docs/vector-file.md -->
+
+<!-- include src/dotnet-openai/Docs/vector-file-list.md -->
 
 ## Models
 

--- a/src/Tests/RangeTests.cs
+++ b/src/Tests/RangeTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+
+namespace Devlooped.OpenAI;
+
+public class RangeTests
+{
+    [Fact]
+    public async Task ApplyRange()
+    {
+        var list = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var rangeString = "2..5";
+        var result = await ApplyRangeAsync(list, rangeString);
+
+        Assert.Equal(new List<int> { 3, 4, 5 }, result);
+    }
+
+    [Fact]
+    public async Task ApplyRangeFromEnd()
+    {
+        var list = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var rangeString = "5..^2";
+        var result = await ApplyRangeAsync(list, rangeString);
+
+        Assert.Equal(new List<int> { 6, 7, 8 }, result);
+    }
+
+    [Fact]
+    public async Task ApplyRangeToEnd()
+    {
+        var list = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var rangeString = "5..";
+        var result = await ApplyRangeAsync(list, rangeString);
+
+        Assert.Equal(new List<int> { 6, 7, 8, 9, 10 }, result);
+    }
+
+    [Fact]
+    public async Task ThrowsInvalidRangeExpression()
+    {
+        var list = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var rangeString = "invalid..range";
+
+        var ex = await Assert.ThrowsAsync<CompilationErrorException>(async () => await ApplyRangeAsync(list, rangeString));
+    }
+
+    public static async Task<List<T>> ApplyRangeAsync<T>(List<T> collection, string rangeString)
+    {
+        var script = CSharpScript.Create<List<T>>(
+            $"return Collection[{rangeString}];",
+            ScriptOptions.Default.WithImports("System", "System.Collections.Generic"),
+            globalsType: typeof(ScriptGlobals<T>)
+        ).CreateDelegate();
+
+        var globals = new ScriptGlobals<T> { Collection = collection };
+        return await script(globals);
+    }
+
+    public class ScriptGlobals<T>
+    {
+        public required List<T> Collection { get; set; }
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet-openai/Docs/file-list.md
+++ b/src/dotnet-openai/Docs/file-list.md
@@ -1,0 +1,27 @@
+﻿```shell
+> openai file list --help
+DESCRIPTION:
+List files
+
+USAGE:
+    openai file list [OPTIONS]
+
+EXAMPLES:
+    openai file list --jq '.[].id'
+    openai file list --jq ".[] | { id: .id, name: .filename, purpose: .purpose 
+}"
+    openai file list --jq ".[] | select(.sizeInBytes > 100000) | .id"
+
+OPTIONS:
+    -h, --help                  Prints help information                         
+        --jq [EXPRESSION]       Filter JSON output using a jq expression        
+        --json                  Output as JSON. Implied when using --jq         
+        --monochrome            Disable colors when rendering JSON to the       
+                                console                                         
+        --range [EXPRESSION]    C# range expression to flexibly slice results   
+        --skip [SKIP]           Number of items to skip from the results        
+        --take [TAKE]           Number of items to take from the results        
+    -p, --purpose [PURPOSE]     Purpose of the file (assistants,                
+                                assistants_output, batch, batch_output, evals,  
+                                fine-tune, fine-tune-results, user_data, vision)
+```

--- a/src/dotnet-openai/Docs/vector-file-list.md
+++ b/src/dotnet-openai/Docs/vector-file-list.md
@@ -1,0 +1,29 @@
+﻿```shell
+> openai vector file list --help
+DESCRIPTION:
+List files associated with vector store
+
+USAGE:
+    openai vector file list <STORE_ID> [OPTIONS]
+
+ARGUMENTS:
+    <STORE_ID>    The ID of the vector store
+
+OPTIONS:
+                                DEFAULT                                         
+    -h, --help                               Prints help information            
+        --jq [EXPRESSION]                    Filter JSON output using a jq      
+                                             expression                         
+        --json                               Output as JSON. Implied when using 
+                                             --jq                               
+        --monochrome                         Disable colors when rendering JSON 
+                                             to the console                     
+        --range [EXPRESSION]                 C# range expression to flexibly    
+                                             slice results                      
+        --skip [SKIP]                        Number of items to skip from the   
+                                             results                            
+        --take [TAKE]                        Number of items to take from the   
+                                             results                            
+    -f, --filter                completed    Filter by status (in_progress,     
+                                             completed, failed, cancelled)      
+```

--- a/src/dotnet-openai/Docs/vector-list.md
+++ b/src/dotnet-openai/Docs/vector-list.md
@@ -1,0 +1,18 @@
+﻿```shell
+> openai vector list --help
+DESCRIPTION:
+List vector stores
+
+USAGE:
+    openai vector list [OPTIONS]
+
+OPTIONS:
+    -h, --help                  Prints help information                         
+        --jq [EXPRESSION]       Filter JSON output using a jq expression        
+        --json                  Output as JSON. Implied when using --jq         
+        --monochrome            Disable colors when rendering JSON to the       
+                                console                                         
+        --range [EXPRESSION]    C# range expression to flexibly slice results   
+        --skip [SKIP]           Number of items to skip from the results        
+        --take [TAKE]           Number of items to take from the results        
+```

--- a/src/dotnet-openai/File/DeleteCommand.cs
+++ b/src/dotnet-openai/File/DeleteCommand.cs
@@ -13,7 +13,7 @@ class DeleteCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
         var response = await oai.GetOpenAIFileClient().DeleteFileAsync(settings.ID);
         if (settings.Json)
         {
-            return console.RenderJson(response.Value, settings, cts.Token);
+            return console.RenderJson(response.GetRawResponse().Content.ToString(), settings, cts.Token);
         }
         else
         {

--- a/src/dotnet-openai/File/ListCommand.cs
+++ b/src/dotnet-openai/File/ListCommand.cs
@@ -1,5 +1,8 @@
-﻿using System.ComponentModel;
+﻿using System.ClientModel;
+using System.ComponentModel;
+using Humanizer;
 using OpenAI;
+using OpenAI.Files;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using ClosedAI = OpenAI;
@@ -11,40 +14,67 @@ class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSourc
 {
     public override async Task<int> ExecuteAsync(CommandContext context, ListSettings settings)
     {
+        ClientResult<OpenAIFileCollection> result;
+
         if (!settings.Purpose.IsSet)
         {
-            var unfiltered = await oai.GetOpenAIFileClient().GetFilesAsync();
-            return console.RenderJson(unfiltered.Value, settings, cts.Token);
+            result = await oai.GetOpenAIFileClient().GetFilesAsync();
+        }
+        else
+        {
+            var purpose = settings.Purpose.Value switch
+            {
+                FilePurpose.Assistants => ClosedAI.Files.FilePurpose.Assistants,
+                FilePurpose.AssistantsOutput => ClosedAI.Files.FilePurpose.AssistantsOutput,
+                FilePurpose.Batch => ClosedAI.Files.FilePurpose.Batch,
+                FilePurpose.BatchOutput => ClosedAI.Files.FilePurpose.BatchOutput,
+                FilePurpose.Evaluations => ClosedAI.Files.FilePurpose.Evaluations,
+                FilePurpose.FineTune => ClosedAI.Files.FilePurpose.FineTune,
+                FilePurpose.FineTuneResults => ClosedAI.Files.FilePurpose.FineTuneResults,
+                FilePurpose.UserData => ClosedAI.Files.FilePurpose.UserData,
+                FilePurpose.Vision => ClosedAI.Files.FilePurpose.Vision,
+                var value => throw new InvalidOperationException($"Invalid purpose '{DisplayValue.ToString(value)}'"),
+            };
+
+            result = await oai.GetOpenAIFileClient().GetFilesAsync(purpose);
         }
 
-        var purpose = settings.Purpose.Value switch
-        {
-            FilePurpose.Assistants => ClosedAI.Files.FilePurpose.Assistants,
-            FilePurpose.AssistantsOutput => ClosedAI.Files.FilePurpose.AssistantsOutput,
-            FilePurpose.Batch => ClosedAI.Files.FilePurpose.Batch,
-            FilePurpose.BatchOutput => ClosedAI.Files.FilePurpose.BatchOutput,
-            FilePurpose.Evaluations => ClosedAI.Files.FilePurpose.Evaluations,
-            FilePurpose.FineTune => ClosedAI.Files.FilePurpose.FineTune,
-            FilePurpose.FineTuneResults => ClosedAI.Files.FilePurpose.FineTuneResults,
-            FilePurpose.UserData => ClosedAI.Files.FilePurpose.UserData,
-            FilePurpose.Vision => ClosedAI.Files.FilePurpose.Vision,
-            var value => throw new InvalidOperationException($"Invalid purpose '{DisplayValue.ToString(value)}'"),
-        };
+        if (settings.Json)
+            return console.RenderJson(settings.ApplyFilters(result.GetRawResponse()), settings, cts.Token);
 
-        var filtered = await oai.GetOpenAIFileClient().GetFilesAsync(purpose);
-        return console.RenderJson(filtered.Value, settings, cts.Token);
+        var table = new Table().Border(TableBorder.Rounded)
+                               .AddColumn("[lime]ID[/]")
+                               .AddColumn("[lime]Name[/]")
+                               .AddColumn("[lime]Status[/]")
+                               .AddColumns("[lime]Size[/]");
+
+        // Adding live for better user feedback on amount of data.
+        console.Live(table)
+            // Clear the "progress" table since we render the full one at the end.
+            .AutoClear(true)
+            .Start(ctx =>
+            {
+                ctx.UpdateTarget(table);
+                foreach (var file in settings.ApplyFilters(result.Value.ToList()))
+                {
+                    table.AddRow(file.Id, file.Filename, file.Status.ToString(), file.SizeInBytes.GetValueOrDefault().Bytes().Humanize());
+                    // refresh every 20 items
+                    if (table.Rows.Count % 20 == 0)
+                    {
+                        ctx.Refresh();
+                    }
+                }
+            });
+
+        console.Write(table);
+
+        return 0;
     }
 
-    public class ListSettings : JsonCommandSettings
+    public class ListSettings : ListCommandSettings
     {
         [DisplayValueDescription<FilePurpose>("Purpose of the file")]
         [CommandOption("-p|--purpose [PURPOSE]")]
         public FlagValue<FilePurpose> Purpose { get; set; } = new();
     }
-
-    //public enum Order
-    //{
-    //    [Description("asc")] Ascending,
-    //    [Description("desc")] Descending
-    //}
 }

--- a/src/dotnet-openai/File/UploadCommand.cs
+++ b/src/dotnet-openai/File/UploadCommand.cs
@@ -20,7 +20,7 @@ class UploadCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
 
         if (settings.Json)
         {
-            return console.RenderJson(response.Value, settings, cts.Token);
+            return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
         }
         else
         {

--- a/src/dotnet-openai/File/ViewCommand.cs
+++ b/src/dotnet-openai/File/ViewCommand.cs
@@ -12,7 +12,7 @@ class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSourc
     {
         var response = await oai.GetOpenAIFileClient().GetFileAsync(settings.ID);
 
-        return console.RenderJson(response.Value, settings, cts.Token);
+        return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
     }
 
     public class ViewSettings : JsonCommandSettings

--- a/src/dotnet-openai/JsonOutput.cs
+++ b/src/dotnet-openai/JsonOutput.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.ClientModel.Primitives;
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -40,6 +41,12 @@ static class JsonOutput
         }
         return RenderJson(console, json, jq, monochrome, cancellation);
     }
+
+    public static int RenderJson(this IAnsiConsole console, PipelineResponse response, JsonCommandSettings settings, CancellationToken cancellation)
+        => RenderJson(console, response.Content.ToString(), settings.JQ, settings.Monochrome, cancellation);
+
+    public static int RenderJson(this IAnsiConsole console, string json, JsonCommandSettings settings, CancellationToken cancellation)
+        => RenderJson(console, json, settings.JQ, settings.Monochrome, cancellation);
 
     public static int RenderJson(this IAnsiConsole console, string json, FlagValue<string> jq, bool monochrome = false, CancellationToken cancellation = default)
     {

--- a/src/dotnet-openai/ListCommandSettings.cs
+++ b/src/dotnet-openai/ListCommandSettings.cs
@@ -1,0 +1,102 @@
+﻿using System.ClientModel.Primitives;
+using System.ComponentModel;
+using System.Text.Json.Nodes;
+using Microsoft.CodeAnalysis.CSharp.Scripting;
+using Microsoft.CodeAnalysis.Scripting;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Devlooped.OpenAI;
+
+public class ListCommandSettings : JsonCommandSettings
+{
+    [Description("C# range expression to flexibly slice results")]
+    [CommandOption("--range [EXPRESSION]")]
+    public FlagValue<string> Range { get; set; } = new();
+
+    [Description("Number of items to skip from the results")]
+    [CommandOption("--skip [SKIP]")]
+    public FlagValue<int> Skip { get; set; } = new();
+
+    [Description("Number of items to take from the results")]
+    [CommandOption("--take [TAKE]")]
+    public FlagValue<int> Take { get; set; } = new();
+
+    public override ValidationResult Validate()
+    {
+        if (Range.IsSet && (Skip.IsSet || Take.IsSet))
+        {
+            return ValidationResult.Error("Cannot use --range with --skip or --take");
+        }
+
+        if (Range.IsSet)
+        {
+            // Attempt compilation with an arbitrary type to ensure expression is valid
+            try
+            {
+                Compile<int>(Range.Value);
+            }
+            catch (CompilationErrorException ex)
+            {
+                return ValidationResult.Error("Invalid range expression: " + string.Join(", ", ex.Diagnostics));
+            }
+        }
+
+        return base.Validate();
+    }
+
+    public List<T> ApplyFilters<T>(IEnumerable<T> values) => ApplyFilters(values.ToList());
+
+    public List<T> ApplyFilters<T>(List<T> collection)
+    {
+        if (Range.IsSet)
+        {
+            return ApplyRangeAsync(collection, Range.Value).GetAwaiter().GetResult();
+        }
+        if (Skip.IsSet)
+        {
+            collection = [.. collection.Skip(Skip.Value)];
+        }
+        if (Take.IsSet)
+        {
+            collection = [.. collection.Take(Take.Value)];
+        }
+        return collection;
+    }
+
+    public string ApplyFilters(PipelineResponse response) => ApplyFilters(response.Content.ToString());
+
+    public string ApplyFilters(string json)
+    {
+        var node = JsonNode.Parse(json);
+        if (node is null || node.Root.GetValueKind() != System.Text.Json.JsonValueKind.Object ||
+            node["object"]?.ToString() != "list")
+            throw new ArgumentException("Expected a response JSON object with \"object\": \"list\"");
+
+        var data = node["data"];
+        if (data is null || data.GetValueKind() != System.Text.Json.JsonValueKind.Array)
+            throw new ArgumentException("Expected a response JSON object with \"data\": []");
+
+        var list = ApplyFilters([.. ((JsonArray)data).AsEnumerable()]);
+        return new JsonArray([.. list.Select(x => x.DeepClone())]).ToJsonString();
+    }
+
+    static ScriptRunner<List<T>> Compile<T>(string range)
+        => CSharpScript.Create<List<T>>(
+                $"return Collection[{range}];",
+                ScriptOptions.Default.WithImports("System", "System.Collections.Generic"),
+                globalsType: typeof(ScriptGlobals<T>)
+            ).CreateDelegate();
+
+    public static async Task<List<T>> ApplyRangeAsync<T>(List<T> collection, string range)
+    {
+        var script = Compile<T>(range);
+
+        return await script(new ScriptGlobals<T> { Collection = collection });
+    }
+
+    public class ScriptGlobals<T>
+    {
+        public required List<T> Collection { get; set; }
+    }
+}

--- a/src/dotnet-openai/Models/ListCommand.cs
+++ b/src/dotnet-openai/Models/ListCommand.cs
@@ -6,9 +6,9 @@ using Spectre.Console.Cli;
 namespace Devlooped.OpenAI.Models;
 
 [Description("List available models")]
-class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<JsonCommandSettings>
+class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ListCommandSettings>
 {
-    public override int Execute(CommandContext context, JsonCommandSettings settings)
+    public override int Execute(CommandContext context, ListCommandSettings settings)
     {
         var result = oai.GetOpenAIModelClient().GetModels(cts.Token);
         if (result is null)
@@ -17,6 +17,19 @@ class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSourc
             return -1;
         }
 
-        return console.RenderJson(result.Value, settings, cts.Token);
+        if (settings.Json)
+            return console.RenderJson(settings.ApplyFilters(result.GetRawResponse()), settings, cts.Token);
+
+        var table = new Table().Border(TableBorder.Rounded)
+                               .AddColumn("[lime]ID[/]")
+                               .AddColumn("[lime]Owner[/]");
+
+        foreach (var model in settings.ApplyFilters(result.Value).OrderBy(x => x.Id))
+        {
+            table.AddRow(model.Id, model.OwnedBy);
+        }
+
+        console.Write(table);
+        return 0;
     }
 }

--- a/src/dotnet-openai/Models/ViewCommand.cs
+++ b/src/dotnet-openai/Models/ViewCommand.cs
@@ -12,7 +12,7 @@ class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSourc
     {
         var result = oai.GetOpenAIModelClient().GetModel(settings.Id, cts.Token);
 
-        return console.RenderJson(result.Value, settings, cts.Token);
+        return console.RenderJson(result.GetRawResponse(), settings, cts.Token);
     }
 
     public class Settings : JsonCommandSettings

--- a/src/dotnet-openai/Vectors/CreateCommand.cs
+++ b/src/dotnet-openai/Vectors/CreateCommand.cs
@@ -35,19 +35,21 @@ class CreateCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
         var store = await console.Status().StartAsync("Creating vector store", async ctx =>
         {
             var result = await oai.GetVectorStoreClient().CreateVectorStoreAsync(settings.WaitForCompletion, options, cts.Token);
-            return result.Value;
+            return result;
         });
 
-        if (store is null)
+        var json = store.GetRawResponse().Content.ToString();
+        if (store.Value is null)
         {
-            console.MarkupLine($":cross_mark: Failed to create vector store");
+            console.MarkupLine($":cross_mark: Failed to create vector store:");
+            console.RenderJson(json, "", settings.Monochrome, cts.Token);
             return -1;
         }
 
         if (settings.Json)
-            return console.RenderJson(store, settings, cts.Token);
+            return console.RenderJson(json, settings, cts.Token);
 
-        console.Write(store.Id);
+        console.Write(store.Value.Id);
         return 0;
     }
 

--- a/src/dotnet-openai/Vectors/DeleteCommand.cs
+++ b/src/dotnet-openai/Vectors/DeleteCommand.cs
@@ -12,8 +12,16 @@ class DeleteCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
     public override int Execute(CommandContext context, DeleteSettings settings)
     {
         var response = oai.GetVectorStoreClient().DeleteVectorStore(settings.ID, cts.Token);
+        var json = response.GetRawResponse();
 
-        return console.RenderJson(response.Value, settings, cts.Token);
+        if (response.GetRawResponse().IsError)
+        {
+            console.MarkupLine($":cross_mark: Failed to delete vector store:");
+            console.RenderJson(json, "", settings.Monochrome, cts.Token);
+            return -1;
+        }
+
+        return console.RenderJson(json, settings, cts.Token);
     }
 
     public class DeleteSettings : JsonCommandSettings

--- a/src/dotnet-openai/Vectors/FileAddCommand.cs
+++ b/src/dotnet-openai/Vectors/FileAddCommand.cs
@@ -45,9 +45,10 @@ class FileAddCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSo
         var vectors = oai.GetVectorStoreClient();
 
         var response = await vectors.GetFileAssociationAsync(settings.StoreId, settings.FileId, cts.Token);
-        if (response.Value is null)
+        if (response.Value is null || response.GetRawResponse().IsError)
         {
-            console.MarkupLine($":cross_mark: Failed to add file to vector store");
+            console.MarkupLine($":cross_mark: Failed to add file to vector store:");
+            console.RenderJson(response.GetRawResponse(), "", settings.Monochrome, cts.Token);
             return -1;
         }
 
@@ -62,7 +63,7 @@ class FileAddCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSo
             }
         }
 
-        return console.RenderJson(response.GetRawResponse().Content.ToString(), settings.JQ, settings.Monochrome, cts.Token);
+        return console.RenderJson(response.GetRawResponse(), settings.JQ, settings.Monochrome, cts.Token);
     }
 
     public class FileAddCommandSettings : FileCommandSettings

--- a/src/dotnet-openai/Vectors/FileRemoveCommand.cs
+++ b/src/dotnet-openai/Vectors/FileRemoveCommand.cs
@@ -13,6 +13,6 @@ class FileRemoveCommand(OpenAIClient oai, IAnsiConsole console, CancellationToke
     {
         var response = oai.GetVectorStoreClient().RemoveFileFromStore(settings.StoreId, settings.FileId, cts.Token);
 
-        return console.RenderJson(response.Value, settings, cts.Token);
+        return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
     }
 }

--- a/src/dotnet-openai/Vectors/FileViewCommand.cs
+++ b/src/dotnet-openai/Vectors/FileViewCommand.cs
@@ -13,6 +13,6 @@ class FileViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenS
     {
         var response = oai.GetVectorStoreClient().GetFileAssociation(settings.StoreId, settings.FileId, cts.Token);
 
-        return console.RenderJson(response.Value, settings, cts.Token);
+        return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
     }
 }

--- a/src/dotnet-openai/Vectors/ListCommand.cs
+++ b/src/dotnet-openai/Vectors/ListCommand.cs
@@ -7,9 +7,9 @@ namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("List vector stores")]
-class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<JsonCommandSettings>
+class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ListCommandSettings>
 {
-    public override int Execute(CommandContext context, JsonCommandSettings settings)
+    public override int Execute(CommandContext context, ListCommandSettings settings)
     {
         var result = oai.GetVectorStoreClient().GetVectorStores();
         if (result is null)

--- a/src/dotnet-openai/Vectors/ModifyCommand.cs
+++ b/src/dotnet-openai/Vectors/ModifyCommand.cs
@@ -33,12 +33,8 @@ class ModifyCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
             return -1;
         }
 
-        ////if (settings.Json)
-        return console.RenderJson(result.Value, settings, cts.Token);
-
-        // TODO: Render the result as a table
-        //console.Write(result.Value..Id);
-        //return 0;
+        // TODO: add non-JSON output?
+        return console.RenderJson(result.GetRawResponse(), settings, cts.Token);
     }
 
     public class ModifySettings : JsonCommandSettings

--- a/src/dotnet-openai/Vectors/ViewCommand.cs
+++ b/src/dotnet-openai/Vectors/ViewCommand.cs
@@ -13,7 +13,8 @@ class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSourc
     {
         var response = oai.GetVectorStoreClient().GetVectorStore(settings.ID, cts.Token);
 
-        return console.RenderJson(response.Value, settings, cts.Token);
+        // TODO: add non-JSON output?
+        return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
     }
 
     public class ViewSettings : JsonCommandSettings

--- a/src/dotnet-openai/dotnet-openai.csproj
+++ b/src/dotnet-openai/dotnet-openai.csproj
@@ -49,9 +49,12 @@
     <CommandHelp Include="auth logout" />
     <CommandHelp Include="auth status" />
     <CommandHelp Include="file" />
+    <CommandHelp Include="file list" />
     <CommandHelp Include="model" />
     <CommandHelp Include="vector" />
+    <CommandHelp Include="vector list" />
     <CommandHelp Include="vector file" />
+    <CommandHelp Include="vector file list" />
   </ItemGroup>
 
   <Target Name="RenderHelp" AfterTargets="Build" Condition="$(DesignTimeBuild) != 'true' and '$(OS)' == 'Windows_NT'">

--- a/src/dotnet-openai/dotnet-openai.csproj
+++ b/src/dotnet-openai/dotnet-openai.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Devlooped.JQ" Version="1.7.1.8" />
+    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
@@ -30,6 +31,7 @@
     <PackageReference Include="ThisAssembly.Git" Version="2.0.12" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Project" Version="2.0.12" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="2.0.12" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.13.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We switch now to rendering the underlying JSON response from the APIs, so that they match the documentation from OpenAI for further JQ querying, which is far better than serializing the C#-view of the generated APIs.

This is particularly useful for cases where re-serializing loses data, such as the attributes associated with a vector file.

We fix setting file attributes for a vector store file, which is key to performing semantic file search downsteam.

Finally, we provide --skip, --take and more importantly --range (with C# range expression syntax) for slicing the results from the list commands, since otherwise they can be quite overwhelming.

For large lists, also took the chance to do live rendering while we're collecting results, and a final table rendering for whole-table output without loss of data.