### PR TITLE
Unify formatting and filtering across list/view

### DIFF
--- a/src/dotnet-openai/File/ListCommand.cs
+++ b/src/dotnet-openai/File/ListCommand.cs
@@ -42,11 +42,12 @@ class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSourc
         if (settings.Json)
             return console.RenderJson(settings.ApplyFilters(result.GetRawResponse()), settings, cts.Token);
 
-        var table = new Table().Border(TableBorder.Rounded)
-                               .AddColumn("[lime]ID[/]")
-                               .AddColumn("[lime]Name[/]")
-                               .AddColumn("[lime]Status[/]")
-                               .AddColumns("[lime]Size[/]");
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .AddColumn("[lime]ID[/]")
+            .AddColumn("[lime]Name[/]")
+            .AddColumn("[lime]Status[/]")
+            .AddColumns("[lime]Size[/]");
 
         // Adding live for better user feedback on amount of data.
         console.Live(table)

--- a/src/dotnet-openai/File/ViewCommand.cs
+++ b/src/dotnet-openai/File/ViewCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Humanizer;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -12,7 +13,23 @@ class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSourc
     {
         var response = await oai.GetOpenAIFileClient().GetFileAsync(settings.ID);
 
-        return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
+        if (settings.Json)
+            return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
+
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .AddColumn("[lime]ID[/]")
+            .AddColumn("[lime]Name[/]")
+            .AddColumn("[lime]Status[/]")
+            .AddColumns("[lime]Size[/]");
+
+        table.AddRow(response.Value.Id, response.Value.Filename,
+            response.Value.Status.ToString(),
+            response.Value.SizeInBytes.GetValueOrDefault().Bytes().Humanize());
+
+        console.Write(table);
+
+        return 0;
     }
 
     public class ViewSettings : JsonCommandSettings

--- a/src/dotnet-openai/Vectors/ModifyCommand.cs
+++ b/src/dotnet-openai/Vectors/ModifyCommand.cs
@@ -3,12 +3,13 @@ using OpenAI;
 using OpenAI.VectorStores;
 using Spectre.Console;
 using Spectre.Console.Cli;
+using static Devlooped.OpenAI.Vectors.ModifyCommand;
 
 namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("Modify a vector store")]
-class ModifyCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<ModifyCommand.ModifySettings>
+class ModifyCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<ModifySettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, ModifySettings settings)
     {
@@ -26,7 +27,7 @@ class ModifyCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
             options.ExpirationPolicy = new VectorStoreExpirationPolicy(VectorStoreExpirationAnchor.LastActiveAt, settings.ExpiresAfter.Value);
         }
 
-        var result = await oai.GetVectorStoreClient().ModifyVectorStoreAsync(settings.ID, options, cts.Token);
+        var result = await oai.GetVectorStoreClient().ModifyVectorStoreAsync(settings.Id, options, cts.Token);
         if (result.Value is null)
         {
             console.MarkupLine($":cross_mark: Failed to modify vector store");
@@ -41,7 +42,7 @@ class ModifyCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
     {
         [Description("The ID of the vector store")]
         [CommandArgument(0, "<ID>")]
-        public required string ID { get; init; }
+        public required string Id { get; init; }
 
         [Description("The name of the vector store")]
         [CommandOption("-n|--name [NAME]")]

--- a/src/dotnet-openai/Vectors/ViewCommand.cs
+++ b/src/dotnet-openai/Vectors/ViewCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Humanizer;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -13,8 +14,27 @@ class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSourc
     {
         var response = oai.GetVectorStoreClient().GetVectorStore(settings.ID, cts.Token);
 
-        // TODO: add non-JSON output?
-        return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
+        if (settings.Json)
+            return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
+
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .AddColumn("[lime]ID[/]")
+            .AddColumn("[lime]Name[/]")
+            .AddColumn("[lime]Files[/]", x => x.RightAligned())
+            .AddColumn("[lime]Size[/]", x => x.RightAligned())
+            .AddColumn("[lime]Last Active[/]");
+
+        table.AddRow(
+            response.Value.Id,
+            response.Value.Name,
+            response.Value.FileCounts.Total.ToString(),
+            response.Value.UsageBytes.Bytes().Humanize(),
+            response.Value.LastActiveAt?.ToString("yyyy-MM-dd T HH:mm") ?? ""
+        );
+
+        console.Write(table);
+        return 0;
     }
 
     public class ViewSettings : JsonCommandSettings


### PR DESCRIPTION
When showing invidual items, use same table format as for lists.

Use the raw response pages/collection across all list commands so we have unified filtering capabilities.