### PR TITLE
Check for updates once a day max unless forced

### DIFF
--- a/src/dotnet-openai/dotnet-openai.csproj
+++ b/src/dotnet-openai/dotnet-openai.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Devlooped.JQ" Version="1.7.1.8" />
+    <PackageReference Include="DotNetConfig" Version="1.2.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />


### PR DESCRIPTION
The --version will always check. Otherwise, we'll check at most once a day to improve performance in repetitive usage.

Fixes #54