### PR TITLE
Leverage DI for command registration too

### DIFF
--- a/src/dotnet-openai/Auth/LoginCommand.cs
+++ b/src/dotnet-openai/Auth/LoginCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using GitCredentialManager;
+using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -19,6 +19,7 @@ namespace Devlooped.OpenAI.Auth;
 
     For example, to use {{{ThisAssembly.Project.ToolCommandName}}} in GitHub Actions, add `OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}` to "env".
     """)]
+[Service]
 public class LoginCommand(IAnsiConsole console, ICredentialStore store) : Command<LoginCommand.LoginSettings>
 {
     public override int Execute(CommandContext context, LoginSettings settings)

--- a/src/dotnet-openai/Auth/LogoutCommand.cs
+++ b/src/dotnet-openai/Auth/LogoutCommand.cs
@@ -1,11 +1,13 @@
 ﻿using System.ComponentModel;
 using GitCredentialManager;
+using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Devlooped.OpenAI.Auth;
 
 [Description("Log out of api.openai.com")]
+[Service]
 class LogoutCommand(ICredentialStore store, IAnsiConsole console) : Command
 {
     public override int Execute(CommandContext context)

--- a/src/dotnet-openai/Auth/StatusCommand.cs
+++ b/src/dotnet-openai/Auth/StatusCommand.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using GitCredentialManager;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -9,6 +10,7 @@ using Spectre.Console.Cli;
 namespace Devlooped.OpenAI.Auth;
 
 [Description("Shows the current authentication status")]
+[Service]
 class StatusCommand(IAnsiConsole console, IConfiguration configuration, ICredentialStore store, OpenAIClient client) : AsyncCommand<StatusCommand.StatusSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, StatusSettings settings)

--- a/src/dotnet-openai/Auth/TokenCommand.cs
+++ b/src/dotnet-openai/Auth/TokenCommand.cs
@@ -1,12 +1,14 @@
 ﻿using System.ComponentModel;
 using GitCredentialManager;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Devlooped.OpenAI.Auth;
 
 [Description($"Print the auth token {ThisAssembly.Project.ToolCommandName} is configured to use")]
+[Service]
 class TokenCommand(IConfiguration configuration, ICredentialStore store, IAnsiConsole console) : Command
 {
     public override int Execute(CommandContext context)

--- a/src/dotnet-openai/Docs/vector.md
+++ b/src/dotnet-openai/Docs/vector.md
@@ -17,7 +17,7 @@ COMMANDS:
     modify <ID>            Modify a vector store                          
     delete <ID>            Delete a vector store by ID                    
     list                   List vector stores                             
-    view <ID>              View a store by its ID                         
+    view                   View a store by its ID                         
     search <ID> <QUERY>    Performs semantic search against a vector store
     file                   Vector store files operations                  
 ```

--- a/src/dotnet-openai/File/DeleteCommand.cs
+++ b/src/dotnet-openai/File/DeleteCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -6,6 +7,7 @@ using Spectre.Console.Cli;
 namespace Devlooped.OpenAI.File;
 
 [Description("Delete a file by its ID.")]
+[Service]
 class DeleteCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<DeleteCommand.DeleteSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, DeleteSettings settings)
@@ -17,7 +19,7 @@ class DeleteCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
         }
         else
         {
-            console.Write(response.Value.Deleted.ToString().ToLowerInvariant());
+            console.WriteLine(response.Value.Deleted.ToString().ToLowerInvariant());
             return 0;
         }
     }

--- a/src/dotnet-openai/File/ListCommand.cs
+++ b/src/dotnet-openai/File/ListCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System.ClientModel;
 using System.ComponentModel;
 using Humanizer;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using OpenAI.Files;
 using Spectre.Console;
@@ -10,6 +11,7 @@ using ClosedAI = OpenAI;
 namespace Devlooped.OpenAI.File;
 
 [Description("List files")]
+[Service]
 class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<ListCommand.ListSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, ListSettings settings)

--- a/src/dotnet-openai/File/UploadCommand.cs
+++ b/src/dotnet-openai/File/UploadCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using OpenAI.Files;
 using Spectre.Console;
@@ -8,6 +9,7 @@ using Spectre.Console.Cli;
 namespace Devlooped.OpenAI.File;
 
 [Description("Upload a local file, specifying its purpose.")]
+[Service]
 class UploadCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<UploadCommand.UploadSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, UploadSettings settings)

--- a/src/dotnet-openai/File/ViewCommand.cs
+++ b/src/dotnet-openai/File/ViewCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using Humanizer;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -7,6 +8,7 @@ using Spectre.Console.Cli;
 namespace Devlooped.OpenAI.File;
 
 [Description("View a file by its ID.")]
+[Service]
 class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<ViewCommand.ViewSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, ViewSettings settings)

--- a/src/dotnet-openai/Models/ListCommand.cs
+++ b/src/dotnet-openai/Models/ListCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -6,6 +7,7 @@ using Spectre.Console.Cli;
 namespace Devlooped.OpenAI.Models;
 
 [Description("List available models")]
+[Service]
 class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ListCommandSettings>
 {
     public override int Execute(CommandContext context, ListCommandSettings settings)

--- a/src/dotnet-openai/Models/ViewCommand.cs
+++ b/src/dotnet-openai/Models/ViewCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -6,6 +7,7 @@ using Spectre.Console.Cli;
 namespace Devlooped.OpenAI.Models;
 
 [Description("View model details")]
+[Service]
 class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ViewCommand.Settings>
 {
     public override int Execute(CommandContext context, Settings settings)

--- a/src/dotnet-openai/Sponsors/CheckCommand.cs
+++ b/src/dotnet-openai/Sponsors/CheckCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using Devlooped.Sponsors;
+using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using static Devlooped.OpenAI.Sponsors.CheckCommand;
@@ -7,6 +8,7 @@ using static Devlooped.OpenAI.Sponsors.CheckCommand;
 namespace Devlooped.OpenAI.Sponsors;
 
 [Description("Checks the current sponsorship status with [lime]devlooped[/], entirely offline")]
+[Service]
 class CheckCommand(IAnsiConsole console) : Command<CheckSettings>
 {
     public class CheckSettings : CommandSettings
@@ -17,11 +19,10 @@ class CheckCommand(IAnsiConsole console) : Command<CheckSettings>
 
     public override int Execute(CommandContext context, CheckSettings settings)
     {
-        var nonInteractive = !Environment.UserInteractive || Console.IsInputRedirected || Console.IsOutputRedirected;
         // Don't render anything if not interactive, so we don't disrupt usage in CI for example.
         // In GH actions, console input/output is redirected, for example, and output is redirected 
         // when using the app in a powershell pipeline or capturing its output in a variable.
-        if (nonInteractive)
+        if (App.IsNonInteractive)
             return 0;
 
         // Check if we have a manifest at all

--- a/src/dotnet-openai/Vectors/CreateCommand.cs
+++ b/src/dotnet-openai/Vectors/CreateCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using OpenAI.VectorStores;
 using Spectre.Console;
@@ -8,6 +9,7 @@ namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("Creates a vector store")]
+[Service]
 class CreateCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<CreateCommand.CreateSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, CreateSettings settings)

--- a/src/dotnet-openai/Vectors/DeleteCommand.cs
+++ b/src/dotnet-openai/Vectors/DeleteCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -7,6 +8,7 @@ namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("Delete a vector store by ID.")]
+[Service]
 class DeleteCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<DeleteCommand.DeleteSettings>
 {
     public override int Execute(CommandContext context, DeleteSettings settings)
@@ -21,7 +23,15 @@ class DeleteCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
             return -1;
         }
 
-        return console.RenderJson(json, settings, cts.Token);
+        if (settings.Json)
+        {
+            return console.RenderJson(response.GetRawResponse().Content.ToString(), settings, cts.Token);
+        }
+        else
+        {
+            console.WriteLine(response.Value.Deleted.ToString().ToLowerInvariant());
+            return 0;
+        }
     }
 
     public class DeleteSettings : JsonCommandSettings

--- a/src/dotnet-openai/Vectors/FileAddCommand.cs
+++ b/src/dotnet-openai/Vectors/FileAddCommand.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -11,6 +12,7 @@ namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("Add file to vector store")]
+[Service]
 class FileAddCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<FileAddCommandSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, FileAddCommandSettings settings)

--- a/src/dotnet-openai/Vectors/FileListCommand.cs
+++ b/src/dotnet-openai/Vectors/FileListCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System.ClientModel.Primitives;
 using System.ComponentModel;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using OpenAI.VectorStores;
 using Spectre.Console;
@@ -10,6 +11,7 @@ namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("List files associated with vector store")]
+[Service]
 class FileListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileListCommand.Settings>
 {
     static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)

--- a/src/dotnet-openai/Vectors/FileRemoveCommand.cs
+++ b/src/dotnet-openai/Vectors/FileRemoveCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -7,6 +8,7 @@ namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("Remove file from vector store")]
+[Service]
 class FileRemoveCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileCommandSettings>
 {
     public override int Execute(CommandContext context, FileCommandSettings settings)

--- a/src/dotnet-openai/Vectors/FileViewCommand.cs
+++ b/src/dotnet-openai/Vectors/FileViewCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -7,6 +8,7 @@ namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("View file association to a vector store")]
+[Service]
 class FileViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileCommandSettings>
 {
     public override int Execute(CommandContext context, FileCommandSettings settings)

--- a/src/dotnet-openai/Vectors/ListCommand.cs
+++ b/src/dotnet-openai/Vectors/ListCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System.ClientModel.Primitives;
 using System.ComponentModel;
 using Humanizer;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -9,6 +10,7 @@ namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("List vector stores")]
+[Service]
 class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ListCommandSettings>
 {
     public override int Execute(CommandContext context, ListCommandSettings settings)

--- a/src/dotnet-openai/Vectors/ModifyCommand.cs
+++ b/src/dotnet-openai/Vectors/ModifyCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using OpenAI.VectorStores;
 using Spectre.Console;
@@ -9,6 +10,7 @@ namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("Modify a vector store")]
+[Service]
 class ModifyCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<ModifySettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, ModifySettings settings)

--- a/src/dotnet-openai/Vectors/SearchCommand.cs
+++ b/src/dotnet-openai/Vectors/SearchCommand.cs
@@ -3,15 +3,16 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
-using Spectre.Console.Rendering;
 using static Devlooped.OpenAI.Vectors.SearchCommand;
 
 namespace Devlooped.OpenAI.Vectors;
 
 [Description("Performs semantic search against a vector store")]
+[Service]
 class SearchCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<SearchSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, SearchSettings settings)

--- a/src/dotnet-openai/Vectors/ViewCommand.cs
+++ b/src/dotnet-openai/Vectors/ViewCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using Humanizer;
+using Microsoft.Extensions.DependencyInjection;
 using OpenAI;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -8,6 +9,7 @@ namespace Devlooped.OpenAI.Vectors;
 
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("View a store by its ID.")]
+[Service]
 class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ViewCommand.ViewSettings>
 {
     public override int Execute(CommandContext context, ViewSettings settings)

--- a/src/dotnet-openai/dotnet-openai.csproj
+++ b/src/dotnet-openai/dotnet-openai.csproj
@@ -8,6 +8,7 @@
     <Description>An OpenAI CLI</Description>
     <ToolCommandName>openai</ToolCommandName>
     <PackageTags>openai dotnet-tool</PackageTags>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 
     <BuildDate>$([System.DateTime]::Now.ToString("yyyy-MM-dd"))</BuildDate>
     <BuildRef>$(GITHUB_REF_NAME)</BuildRef>
@@ -16,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection" Version="42.42.449-main" PrivateAssets="all" />
     <PackageReference Include="Devlooped.JQ" Version="1.7.1.8" />
     <PackageReference Include="Devlooped.Sponsors.Commands" Version="42.42.1585-main" />
     <PackageReference Include="DotNetConfig" Version="1.2.0" />


### PR DESCRIPTION
This attribute-based approach allows tests to leverage DI to replace the IAnsiConsole too. It should also make console startup faster since resolving the type ctor is done at compile-time.