### PR TITLE
Add ID>Name mapping for vector stores, add end2end test

### DIFF
--- a/.netconfig
+++ b/.netconfig
@@ -140,3 +140,9 @@
 
 	etag = 55ef89e8441156541c1c74a50675b7f56633b56493031f0ffa877460839e3536
 	weak
+[file "src/Tests/Attributes.cs"]
+	url = https://github.com/devlooped/catbag/blob/main/Xunit/Attributes.cs
+	sha = 615c1e2521340dcd85132807b368a52ff53e4ba7
+
+	etag = ec1645067cc2319c2ce3304900c260eb8ec700d50b6d8d62285914a6c96e01f9
+	weak

--- a/src/Tests/Attributes.cs
+++ b/src/Tests/Attributes.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Xunit;
+
+public class SecretsFactAttribute : FactAttribute
+{
+    public static IConfiguration Configuration { get; set; } = new ConfigurationBuilder()
+        .AddEnvironmentVariables()
+        .AddUserSecrets<SecretsFactAttribute>()
+        .Build();
+
+    public SecretsFactAttribute(params string[] secrets)
+    {
+        var missing = new HashSet<string>();
+
+        foreach (var secret in secrets)
+        {
+            if (string.IsNullOrEmpty(Configuration[secret]))
+                missing.Add(secret);
+        }
+
+        if (missing.Count > 0)
+            Skip = "Missing user secrets: " + string.Join(',', missing);
+    }
+}
+
+public class LocalFactAttribute : SecretsFactAttribute
+{
+    public LocalFactAttribute(params string[] secrets) : base(secrets)
+    {
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
+            Skip = "Non-CI test";
+    }
+}
+
+public class CIFactAttribute : FactAttribute
+{
+    public CIFactAttribute()
+    {
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
+            Skip = "CI-only test";
+    }
+}
+
+public class SecretsTheoryAttribute : TheoryAttribute
+{
+    public SecretsTheoryAttribute(params string[] secrets)
+    {
+        var missing = new HashSet<string>();
+
+        foreach (var secret in secrets)
+        {
+            if (string.IsNullOrEmpty(SecretsFactAttribute.Configuration[secret]))
+                missing.Add(secret);
+        }
+
+        if (missing.Count > 0)
+            Skip = "Missing user secrets: " + string.Join(',', missing);
+    }
+}
+
+public class LocalTheoryAttribute : SecretsTheoryAttribute
+{
+    public LocalTheoryAttribute(params string[] secrets) : base(secrets)
+    {
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
+            Skip = "Non-CI test";
+    }
+}
+
+public class CITheoryAttribute : SecretsTheoryAttribute
+{
+    public CITheoryAttribute(params string[] secrets) : base(secrets)
+    {
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI")))
+            Skip = "CI-only test";
+    }
+}
+
+public class DebuggerFactAttribute : FactAttribute
+{
+    public DebuggerFactAttribute()
+    {
+        if (!System.Diagnostics.Debugger.IsAttached)
+            Skip = "Only running in the debugger";
+    }
+}
+
+public class DebuggerTheoryAttribute : TheoryAttribute
+{
+    public DebuggerTheoryAttribute()
+    {
+        if (!System.Diagnostics.Debugger.IsAttached)
+            Skip = "Only running in the debugger";
+    }
+}

--- a/src/Tests/Content.txt
+++ b/src/Tests/Content.txt
@@ -1,0 +1,1 @@
+Daniel (aka kzu) lives in Buenos Aires, Argentina

--- a/src/Tests/Content2.txt
+++ b/src/Tests/Content2.txt
@@ -1,0 +1,1 @@
+Daniel (aka kzu) is married to Analia

--- a/src/Tests/EndToEnd.cs
+++ b/src/Tests/EndToEnd.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using Devlooped.OpenAI.Vectors;
+using DotNetConfig;
+using GitCredentialManager;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenAI;
+using Spectre.Console;
+using Spectre.Console.Advanced;
+using Spectre.Console.Cli;
+using Spectre.Console.Rendering;
+using Spectre.Console.Testing;
+using static System.Collections.Specialized.BitVector32;
+
+namespace Devlooped.OpenAI;
+
+#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+public class EndToEnd : IDisposable
+{
+    readonly ITestOutputHelper output;
+    string? fileId = default;
+    string? storeId = default;
+    IServiceProvider services;
+    TestConsole console = new();
+
+    public EndToEnd(ITestOutputHelper output)
+    {
+        this.output = output;
+        App.Create(console.Wrap(), out var services);
+        this.services = (IServiceProvider)services;
+
+        // Clear all vector stores before starting
+        var oai = this.services.GetRequiredService<OpenAIClient>();
+        var vectors = oai.GetVectorStoreClient();
+
+        Task.WaitAll(vectors
+            .GetVectorStores()
+            .Select(store => vectors.DeleteVectorStoreAsync(store.Id))
+            .ToArray());
+
+        Config.Build(ConfigLevel.Global).RemoveSection("openai", "vectors");
+    }
+
+    public void Dispose()
+    {
+        var oai = this.services.GetRequiredService<OpenAIClient>();
+        var vectors = oai.GetVectorStoreClient();
+
+        Task.WaitAll(vectors
+            .GetVectorStores()
+            .Select(store => vectors.DeleteVectorStoreAsync(store.Id))
+            .ToArray());
+
+        var files = oai.GetOpenAIFileClient();
+        Task.WaitAll(files.GetFiles().Value
+            .Select(file => files.DeleteFileAsync(file.Id))
+            .ToArray());
+
+        output.WriteLine(console.Output);
+        Config.Build(ConfigLevel.Global).RemoveSection("openai", "vectors");
+    }
+
+    [LocalFact]
+    public async Task FullScenario()
+    {
+        Assert.Equal(0, await services.GetRequiredService<Auth.StatusCommand>().ExecuteAsync());
+
+        Assert.Equal(0, await services.GetRequiredService<File.UploadCommand>().ExecuteAsync(new File.UploadCommand.UploadSettings()
+        {
+            File = Path.GetFullPath("./Content.txt"),
+            Purpose = "assistants"
+        }));
+
+        fileId = console.Output.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries)[^1]?.Trim();
+        Assert.NotNull(fileId);
+
+        Assert.Equal(0, await services.GetRequiredService<Vectors.CreateCommand>().ExecuteAsync(new Vectors.CreateCommand.CreateSettings()
+        {
+            Name =
+            {
+                IsSet = true,
+                Value = "foo",
+            },
+            Files = new[] { fileId },
+        }));
+
+        storeId = console.Output.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries)[^1]?.Trim();
+        Assert.NotNull(storeId);
+
+        // Ensure mapping is persisted to config
+        var mapper = services.GetRequiredService<VectorIdMapper>();
+        Assert.True(mapper.TryGetId("foo", out var id));
+        Assert.Equal(storeId, id);
+
+        Assert.Equal(0, await services.GetRequiredService<Vectors.ViewCommand>().ExecuteAsync(new StoreCommandSettings(mapper)
+        {
+            Store = "foo",
+        }));
+
+        // Rename store
+        Assert.Equal(0, await services.GetRequiredService<Vectors.ModifyCommand>().ExecuteAsync(new Vectors.ModifyCommand.ModifySettings(mapper)
+        {
+            Store = "foo",
+            Name =
+            {
+                IsSet = true,
+                Value = "bar",
+            },
+        }));
+
+        Assert.Equal(0, await services.GetRequiredService<Vectors.ViewCommand>().ExecuteAsync(new StoreCommandSettings(mapper)
+        {
+            Store = "bar",
+        }));
+
+        Assert.False(mapper.TryGetId("foo", out id));
+
+        // Perform a search
+        Assert.Equal(0, await services.GetRequiredService<Vectors.SearchCommand>().ExecuteAsync(new SearchCommand.SearchSettings(mapper)
+        {
+            Store = "bar",
+            Query = "where does kzu live?",
+        }));
+
+        Assert.Contains("Argentina", console.Output);
+        Assert.DoesNotContain("Analia", console.Output);
+
+        Assert.Equal(0, await services.GetRequiredService<File.UploadCommand>().ExecuteAsync(new File.UploadCommand.UploadSettings()
+        {
+            File = Path.GetFullPath("./Content2.txt"),
+            Purpose = "assistants"
+        }));
+
+        fileId = console.Output.Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries)[^1]?.Trim();
+        Assert.NotNull(fileId);
+
+        Assert.Equal(0, await services.GetRequiredService<Vectors.FileAddCommand>().ExecuteAsync(new Vectors.FileAddCommand.FileAddCommandSettings(mapper)
+        {
+            Store = "bar",
+            FileId = fileId,
+        }));
+
+        // Perform a search
+        Assert.Equal(0, await services.GetRequiredService<Vectors.SearchCommand>().ExecuteAsync(new SearchCommand.SearchSettings(mapper)
+        {
+            Store = "bar",
+            Query = "who's kzu's wife?",
+        }));
+
+        Assert.Contains("Analia", console.Output);
+    }
+}

--- a/src/Tests/IAnsiConsoleExtensions.cs
+++ b/src/Tests/IAnsiConsoleExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace Devlooped.OpenAI;
+
+public static class IAnsiConsoleExtensions
+{
+    public static IAnsiConsole Wrap(this IAnsiConsole console) => new UndisposableConsole(console);
+
+    class UndisposableConsole(IAnsiConsole console) : IAnsiConsole
+    {
+        public Profile Profile => console.Profile;
+        public IAnsiConsoleCursor Cursor => console.Cursor;
+        public IAnsiConsoleInput Input => console.Input;
+        public IExclusivityMode ExclusivityMode => console.ExclusivityMode;
+        public RenderPipeline Pipeline => console.Pipeline;
+        public void Clear(bool home) => console.Clear(home);
+        public void Write(IRenderable renderable) => console.Write(renderable);
+    }
+}

--- a/src/Tests/ICommandExtensions.cs
+++ b/src/Tests/ICommandExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Spectre.Console.Cli;
+
+namespace Devlooped.OpenAI;
+
+public static class ICommandExtensions
+{
+    static readonly CommandContext EmptyContext = new(Array.Empty<string>(), RemainingArguments.Empty, string.Empty, null);
+
+    public static Task<int> ExecuteAsync<TSettings>(this ICommand<TSettings> command, TSettings settings)
+        where TSettings : CommandSettings
+    {
+        if (settings.Validate() is { Successful: false } validation)
+            throw new Exception(validation.Message);
+
+        return command.Execute(EmptyContext, settings);
+    }
+
+    public static Task<int> ExecuteAsync<TSettings>(this ICommand<TSettings> command, Action<TSettings>? configure = default)
+        where TSettings : CommandSettings, new()
+    {
+        var settings = new TSettings();
+        configure?.Invoke(settings);
+        if (settings.Validate() is { Successful: false } validation)
+            throw new Exception(validation.Message);
+
+        return command.Execute(EmptyContext, settings);
+    }
+
+    class RemainingArguments : IRemainingArguments
+    {
+        public static IRemainingArguments Empty { get; } = new RemainingArguments();
+        RemainingArguments() { }
+        public ILookup<string, string?> Parsed => Enumerable.Empty<string>().ToLookup(x => x, x => default(string));
+        public IReadOnlyList<string> Raw => [];
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.50.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.13.0" />
@@ -19,6 +20,15 @@
   <ItemGroup>
     <Using Include="Xunit" />
     <Using Include="Xunit.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Content2.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Content.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Tests/VectorsTests.cs
+++ b/src/Tests/VectorsTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Spectre.Console.Testing;
+
+namespace Devlooped.OpenAI;
+
+public class VectorsTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task ViewBadId()
+    {
+        var console = new TestConsole();
+        var app = App.Create(console.Wrap());
+
+        Assert.Equal(-1, await app.RunAsync(["vector", "view", "--id", "non-existent-id"]));
+
+        output.WriteLine(console.Output);
+    }
+
+    [Fact]
+    public async Task ViewNonExistentId()
+    {
+        var console = new TestConsole();
+        var app = App.Create(console.Wrap());
+
+        Assert.Equal(-1, await app.RunAsync(["vector", "view", "--id", "vs_foo"]));
+
+        output.WriteLine(console.Output);
+    }
+}

--- a/src/dotnet-openai/App.cs
+++ b/src/dotnet-openai/App.cs
@@ -25,17 +25,19 @@ public static class App
 
     public static CommandApp Create() => Create(out _);
 
-    public static CommandApp Create([NotNull] out IServiceProvider services)
-        => Create(new ServiceCollection(), out services);
+    public static CommandApp Create([NotNull] out ITypeRegistrar registrar)
+        => Create(new ServiceCollection(), out registrar);
 
-    public static CommandApp Create(IAnsiConsole console, [NotNull] out IServiceProvider services)
+    public static CommandApp Create(IAnsiConsole console) => Create(console, out _);
+
+    public static CommandApp Create(IAnsiConsole console, [NotNull] out ITypeRegistrar registrar)
     {
-        var app = Create(new ServiceCollection().AddSingleton(console), out services);
+        var app = Create(new ServiceCollection().AddSingleton(console), out registrar);
         app.Configure(config => config.ConfigureConsole(console));
         return app;
     }
 
-    static CommandApp Create(IServiceCollection collection, [NotNull] out IServiceProvider services)
+    static CommandApp Create(IServiceCollection collection, [NotNull] out ITypeRegistrar registrar)
     {
         var config = new ConfigurationBuilder()
             .AddEnvironmentVariables()
@@ -65,9 +67,8 @@ public static class App
         collection.ConfigureSponsors();
         collection.AddServices();
 
-        var registrar = new TypeRegistrar(collection);
+        registrar = new TypeRegistrar(collection);
         var app = new CommandApp(registrar);
-        registrar.Services.AddSingleton<ICommandApp>(app);
 
         app.Configure(config =>
         {
@@ -81,8 +82,6 @@ public static class App
         app.UseVectors();
         app.UseModels();
         app.UseSponsors();
-
-        services = registrar.Services.BuildServiceProvider();
 
         return app;
     }

--- a/src/dotnet-openai/Auth/LogoutCommand.cs
+++ b/src/dotnet-openai/Auth/LogoutCommand.cs
@@ -8,7 +8,7 @@ namespace Devlooped.OpenAI.Auth;
 
 [Description("Log out of api.openai.com")]
 [Service]
-class LogoutCommand(ICredentialStore store, IAnsiConsole console) : Command
+public class LogoutCommand(ICredentialStore store, IAnsiConsole console) : Command
 {
     public override int Execute(CommandContext context)
     {

--- a/src/dotnet-openai/Auth/StatusCommand.cs
+++ b/src/dotnet-openai/Auth/StatusCommand.cs
@@ -11,7 +11,7 @@ namespace Devlooped.OpenAI.Auth;
 
 [Description("Shows the current authentication status")]
 [Service]
-class StatusCommand(IAnsiConsole console, IConfiguration configuration, ICredentialStore store, OpenAIClient client) : AsyncCommand<StatusCommand.StatusSettings>
+public class StatusCommand(IAnsiConsole console, IConfiguration configuration, ICredentialStore store, OpenAIClient client) : AsyncCommand<StatusCommand.StatusSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, StatusSettings settings)
     {

--- a/src/dotnet-openai/Auth/TokenCommand.cs
+++ b/src/dotnet-openai/Auth/TokenCommand.cs
@@ -9,7 +9,7 @@ namespace Devlooped.OpenAI.Auth;
 
 [Description($"Print the auth token {ThisAssembly.Project.ToolCommandName} is configured to use")]
 [Service]
-class TokenCommand(IConfiguration configuration, ICredentialStore store, IAnsiConsole console) : Command
+public class TokenCommand(IConfiguration configuration, ICredentialStore store, IAnsiConsole console) : Command
 {
     public override int Execute(CommandContext context)
     {

--- a/src/dotnet-openai/Docs/help.md
+++ b/src/dotnet-openai/Docs/help.md
@@ -20,4 +20,3 @@ COMMANDS:
     vector      
     model       
     sponsor     
-```

--- a/src/dotnet-openai/Docs/vector-file-add.md
+++ b/src/dotnet-openai/Docs/vector-file-add.md
@@ -4,11 +4,11 @@ DESCRIPTION:
 Add file to vector store
 
 USAGE:
-    openai vector file add <STORE_ID> <FILE_ID> [OPTIONS]
+    openai vector file add <STORE> <FILE_ID> [OPTIONS]
 
 ARGUMENTS:
-    <STORE_ID>    The ID of the vector store        
-    <FILE_ID>     File ID to add to the vector store
+    <STORE>      The ID or name of the vector store
+    <FILE_ID>    File ID to add to the vector store
 
 OPTIONS:
     -h, --help               Prints help information                          

--- a/src/dotnet-openai/Docs/vector-file-list.md
+++ b/src/dotnet-openai/Docs/vector-file-list.md
@@ -4,10 +4,10 @@ DESCRIPTION:
 List files associated with vector store
 
 USAGE:
-    openai vector file list <STORE_ID> [OPTIONS]
+    openai vector file list <STORE> [OPTIONS]
 
 ARGUMENTS:
-    <STORE_ID>    The ID of the vector store
+    <STORE>    The ID or name of the vector store
 
 OPTIONS:
                                 DEFAULT                                         

--- a/src/dotnet-openai/Docs/vector-file.md
+++ b/src/dotnet-openai/Docs/vector-file.md
@@ -10,8 +10,8 @@ OPTIONS:
     -h, --help    Prints help information
 
 COMMANDS:
-    add <STORE_ID> <FILE_ID>       Add file to vector store               
-    delete <STORE_ID> <FILE_ID>    Remove file from vector store          
-    list <STORE_ID>                List files associated with vector store
-    view <STORE_ID> <FILE_ID>      View file association to a vector store
+    add <STORE> <FILE_ID>       Add file to vector store               
+    delete <STORE> <FILE_ID>    Remove file from vector store          
+    list <STORE>                List files associated with vector store
+    view <STORE> <FILE_ID>      View file association to a vector store
 ```

--- a/src/dotnet-openai/Docs/vector-search.md
+++ b/src/dotnet-openai/Docs/vector-search.md
@@ -4,15 +4,15 @@ DESCRIPTION:
 Performs semantic search against a vector store
 
 USAGE:
-    openai vector search <ID> <QUERY> [OPTIONS]
+    openai vector search <STORE> <QUERY> [OPTIONS]
 
 EXAMPLES:
     openai vector search mystore "what's the return policy on headphones?" 
 --score 0.7
 
 ARGUMENTS:
-    <ID>       The ID of the vector store
-    <QUERY>    The query to search for   
+    <STORE>    The ID or name of the vector store
+    <QUERY>    The query to search for           
 
 OPTIONS:
                              DEFAULT                                            

--- a/src/dotnet-openai/Docs/vector.md
+++ b/src/dotnet-openai/Docs/vector.md
@@ -13,11 +13,11 @@ OPTIONS:
     -h, --help    Prints help information
 
 COMMANDS:
-    create                 Creates a vector store                         
-    modify <ID>            Modify a vector store                          
-    delete <ID>            Delete a vector store by ID                    
-    list                   List vector stores                             
-    view                   View a store by its ID                         
-    search <ID> <QUERY>    Performs semantic search against a vector store
-    file                   Vector store files operations                  
+    create                    Creates a vector store                         
+    modify <STORE>            Modify a vector store                          
+    delete <STORE>            Delete a vector store by ID or name            
+    list                      List vector stores                             
+    view <STORE>              View a store by its ID or name                 
+    search <STORE> <QUERY>    Performs semantic search against a vector store
+    file                      Vector store files operations                  
 ```

--- a/src/dotnet-openai/File/DeleteCommand.cs
+++ b/src/dotnet-openai/File/DeleteCommand.cs
@@ -8,7 +8,7 @@ namespace Devlooped.OpenAI.File;
 
 [Description("Delete a file by its ID.")]
 [Service]
-class DeleteCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<DeleteCommand.DeleteSettings>
+public class DeleteCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<DeleteCommand.DeleteSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, DeleteSettings settings)
     {

--- a/src/dotnet-openai/File/ListCommand.cs
+++ b/src/dotnet-openai/File/ListCommand.cs
@@ -12,7 +12,7 @@ namespace Devlooped.OpenAI.File;
 
 [Description("List files")]
 [Service]
-class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<ListCommand.ListSettings>
+public class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<ListCommand.ListSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, ListSettings settings)
     {

--- a/src/dotnet-openai/File/UploadCommand.cs
+++ b/src/dotnet-openai/File/UploadCommand.cs
@@ -10,7 +10,7 @@ namespace Devlooped.OpenAI.File;
 
 [Description("Upload a local file, specifying its purpose.")]
 [Service]
-class UploadCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<UploadCommand.UploadSettings>
+public class UploadCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<UploadCommand.UploadSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, UploadSettings settings)
     {

--- a/src/dotnet-openai/File/ViewCommand.cs
+++ b/src/dotnet-openai/File/ViewCommand.cs
@@ -9,7 +9,7 @@ namespace Devlooped.OpenAI.File;
 
 [Description("View a file by its ID.")]
 [Service]
-class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<ViewCommand.ViewSettings>
+public class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<ViewCommand.ViewSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, ViewSettings settings)
     {

--- a/src/dotnet-openai/JsonOutput.cs
+++ b/src/dotnet-openai/JsonOutput.cs
@@ -1,5 +1,4 @@
 ﻿using System.ClientModel.Primitives;
-using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -26,10 +25,7 @@ static class JsonOutput
     };
 
     public static int RenderJson<T>(this IAnsiConsole console, T value, JsonCommandSettings settings, CancellationToken cancellation)
-        => RenderJson(console, value, settings.JQ, settings.Monochrome, cancellation);
-
-    public static int RenderJson<T>(this IAnsiConsole console, T value, FlagValue<string> jq, bool monochrome = false, CancellationToken cancellation = default)
-        => RenderJson(console, value, jq.IsSet ? jq.Value : default, monochrome, cancellation);
+        => RenderJson(console, value, settings.JQ.IsSet ? settings.JQ.Value : default, settings.Monochrome, cancellation);
 
     public static int RenderJson<T>(this IAnsiConsole console, T value, string? jq = default, bool monochrome = false, CancellationToken cancellation = default)
     {
@@ -41,6 +37,12 @@ static class JsonOutput
         }
         return RenderJson(console, json, jq, monochrome, cancellation);
     }
+
+    public static int RenderJson(this IAnsiConsole console, PipelineResponse response, string? jq = default, bool monochrome = false, CancellationToken cancellation = default)
+        => RenderJson(console, response.Content.ToString(), "", monochrome, cancellation);
+
+    public static int RenderJson(this IAnsiConsole console, PipelineResponse response, bool monochrome = false, CancellationToken cancellation = default)
+        => RenderJson(console, response.Content.ToString(), "", monochrome, cancellation);
 
     public static int RenderJson(this IAnsiConsole console, PipelineResponse response, JsonCommandSettings settings, CancellationToken cancellation)
         => RenderJson(console, response.Content.ToString(), settings.JQ, settings.Monochrome, cancellation);
@@ -60,7 +62,7 @@ static class JsonOutput
 
     public static int RenderJson(this IAnsiConsole console, string json, string jq, bool monochrome = false, CancellationToken cancellation = default)
     {
-        var info = new ProcessStartInfo(JQ.Path)
+        var info = new System.Diagnostics.ProcessStartInfo(JQ.Path)
         {
             RedirectStandardError = true,
             RedirectStandardOutput = true,
@@ -90,7 +92,7 @@ static class JsonOutput
             info.ArgumentList.Add(jq.Trim());
         }
 
-        var process = Process.Start(info);
+        var process = System.Diagnostics.Process.Start(info);
         if (process == null)
         {
             console.MarkupLine($":cross_mark: Could not start JQ from {JQ.Path}");

--- a/src/dotnet-openai/Models/ListCommand.cs
+++ b/src/dotnet-openai/Models/ListCommand.cs
@@ -8,7 +8,7 @@ namespace Devlooped.OpenAI.Models;
 
 [Description("List available models")]
 [Service]
-class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ListCommandSettings>
+public class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ListCommandSettings>
 {
     public override int Execute(CommandContext context, ListCommandSettings settings)
     {

--- a/src/dotnet-openai/Models/ViewCommand.cs
+++ b/src/dotnet-openai/Models/ViewCommand.cs
@@ -8,7 +8,7 @@ namespace Devlooped.OpenAI.Models;
 
 [Description("View model details")]
 [Service]
-class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ViewCommand.Settings>
+public class ViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ViewCommand.Settings>
 {
     public override int Execute(CommandContext context, Settings settings)
     {

--- a/src/dotnet-openai/Sponsors/CheckCommand.cs
+++ b/src/dotnet-openai/Sponsors/CheckCommand.cs
@@ -9,7 +9,7 @@ namespace Devlooped.OpenAI.Sponsors;
 
 [Description("Checks the current sponsorship status with [lime]devlooped[/], entirely offline")]
 [Service]
-class CheckCommand(IAnsiConsole console) : Command<CheckSettings>
+public class CheckCommand(IAnsiConsole console) : Command<CheckSettings>
 {
     public class CheckSettings : CommandSettings
     {

--- a/src/dotnet-openai/TypeRegistrar.cs
+++ b/src/dotnet-openai/TypeRegistrar.cs
@@ -3,30 +3,56 @@ using Spectre.Console.Cli;
 
 namespace Devlooped.OpenAI;
 
-public sealed class TypeRegistrar(IServiceCollection? builder = default) : ITypeRegistrar
+public sealed class TypeRegistrar(IServiceCollection? builder = default) : ITypeRegistrar, IServiceProvider
 {
     readonly IServiceCollection builder = builder ?? new ServiceCollection();
+    IServiceProvider? services;
 
     public IServiceCollection Services => builder;
 
-    public ITypeResolver Build() => new TypeResolver(builder.BuildServiceProvider());
+    public object? GetService(Type serviceType) => Build().GetService(serviceType);
 
-    public void Register(Type service, Type implementation) => builder.AddSingleton(service, implementation);
+    public void Register(Type service, Type implementation)
+    {
+        ResetServiceProvider();
+        builder.AddSingleton(service, implementation);
+    }
 
-    public void RegisterInstance(Type service, object implementation) => builder.AddSingleton(service, implementation);
+    public void RegisterInstance(Type service, object implementation)
+    {
+        ResetServiceProvider();
+        builder.AddSingleton(service, implementation);
+    }
 
     public void RegisterLazy(Type service, Func<object> func)
     {
         ThrowIfNull(func);
+        ResetServiceProvider();
         builder.AddSingleton(service, (provider) => func());
     }
 
-    sealed class TypeResolver(IServiceProvider provider) : ITypeResolver, IDisposable
+    IServiceProvider Build() => services ??= builder.BuildServiceProvider();
+
+    ITypeResolver ITypeRegistrar.Build() => new TypeResolver(this);
+
+    void ResetServiceProvider()
     {
-        readonly IServiceProvider provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        // Reset the service provider
+        lock (this)
+        {
+            (services as IDisposable)?.Dispose();
+            services = null;
+        }
+    }
 
-        public object? Resolve(Type? type) => type == null ? null : provider.GetService(type);
+    sealed class TypeResolver(TypeRegistrar registrar) : ITypeResolver, IServiceProvider, IDisposable
+    {
+        IServiceProvider services = registrar.Build();
 
-        public void Dispose() => (provider as IDisposable)?.Dispose();
+        public object? Resolve(Type? type) => type == null ? null : services.GetService(type);
+
+        public void Dispose() => registrar.ResetServiceProvider();
+
+        public object? GetService(Type serviceType) => services.GetService(serviceType);
     }
 }

--- a/src/dotnet-openai/Vectors/CreateCommand.cs
+++ b/src/dotnet-openai/Vectors/CreateCommand.cs
@@ -10,7 +10,7 @@ namespace Devlooped.OpenAI.Vectors;
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("Creates a vector store")]
 [Service]
-class CreateCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<CreateCommand.CreateSettings>
+public class CreateCommand(OpenAIClient oai, VectorIdMapper mapper, IAnsiConsole console, CancellationTokenSource cts) : AsyncCommand<CreateCommand.CreateSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, CreateSettings settings)
     {
@@ -40,6 +40,9 @@ class CreateCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
             return result;
         });
 
+        if (settings.Name.IsSet)
+            mapper.SetId(settings.Name.Value, store.VectorStoreId);
+
         var json = store.GetRawResponse().Content.ToString();
         if (store.Value is null)
         {
@@ -67,7 +70,7 @@ class CreateCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSou
 
         [Description("File IDs to add to the vector store")]
         [CommandOption("-f|--file")]
-        public List<string> Files { get; set; } = new();
+        public string[] Files { get; set; } = [];
 
         [Description("Metadata to add to the vector store as KEY=VALUE")]
         [CommandOption("-m|--meta")]

--- a/src/dotnet-openai/Vectors/FileCommandSettings.cs
+++ b/src/dotnet-openai/Vectors/FileCommandSettings.cs
@@ -3,12 +3,8 @@ using Spectre.Console.Cli;
 
 namespace Devlooped.OpenAI.Vectors;
 
-public class FileCommandSettings : JsonCommandSettings
+public class FileCommandSettings(VectorIdMapper mapper) : StoreCommandSettings(mapper)
 {
-    [Description("The ID of the vector store")]
-    [CommandArgument(0, "<STORE_ID>")]
-    public required string StoreId { get; init; }
-
     [Description("File ID to add to the vector store")]
     [CommandArgument(1, "<FILE_ID>")]
     public required string FileId { get; init; }

--- a/src/dotnet-openai/Vectors/FileListCommand.cs
+++ b/src/dotnet-openai/Vectors/FileListCommand.cs
@@ -12,7 +12,7 @@ namespace Devlooped.OpenAI.Vectors;
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("List files associated with vector store")]
 [Service]
-class FileListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileListCommand.Settings>
+public class FileListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileListCommand.Settings>
 {
     static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)
     {
@@ -26,7 +26,7 @@ class FileListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenS
             Filter = settings.Filter,
         };
 
-        CollectionResult result = oai.GetVectorStoreClient().GetFileAssociations(settings.StoreId, options, cts.Token);
+        CollectionResult result = oai.GetVectorStoreClient().GetFileAssociations(settings.Store, options, cts.Token);
         if (result is null)
         {
             console.MarkupLine($":cross_mark: Failed to list vector stores");
@@ -70,15 +70,21 @@ class FileListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenS
         return 0;
     }
 
-    public class Settings : ListCommandSettings
+    public class Settings(VectorIdMapper mapper) : ListCommandSettings
     {
-        [Description("The ID of the vector store")]
-        [CommandArgument(0, "<STORE_ID>")]
-        public required string StoreId { get; init; }
+        [Description("The ID or name of the vector store")]
+        [CommandArgument(0, "<STORE>")]
+        public required string Store { get; set; }
 
         [Description("Filter by status (in_progress, completed, failed, cancelled)")]
         [DefaultValue("completed")]
         [CommandOption("-f|--filter")]
         public required string Filter { get; set; } = "completed";
+
+        public override ValidationResult Validate()
+        {
+            Store = mapper.MapName(Store);
+            return base.Validate();
+        }
     }
 }

--- a/src/dotnet-openai/Vectors/FileRemoveCommand.cs
+++ b/src/dotnet-openai/Vectors/FileRemoveCommand.cs
@@ -9,11 +9,11 @@ namespace Devlooped.OpenAI.Vectors;
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("Remove file from vector store")]
 [Service]
-class FileRemoveCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileCommandSettings>
+public class FileRemoveCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileCommandSettings>
 {
     public override int Execute(CommandContext context, FileCommandSettings settings)
     {
-        var response = oai.GetVectorStoreClient().RemoveFileFromStore(settings.StoreId, settings.FileId, cts.Token);
+        var response = oai.GetVectorStoreClient().RemoveFileFromStore(settings.Store, settings.FileId, cts.Token);
 
         return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
     }

--- a/src/dotnet-openai/Vectors/FileViewCommand.cs
+++ b/src/dotnet-openai/Vectors/FileViewCommand.cs
@@ -9,11 +9,11 @@ namespace Devlooped.OpenAI.Vectors;
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("View file association to a vector store")]
 [Service]
-class FileViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileCommandSettings>
+public class FileViewCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileCommandSettings>
 {
     public override int Execute(CommandContext context, FileCommandSettings settings)
     {
-        var response = oai.GetVectorStoreClient().GetFileAssociation(settings.StoreId, settings.FileId, cts.Token);
+        var response = oai.GetVectorStoreClient().GetFileAssociation(settings.Store, settings.FileId, cts.Token);
 
         return console.RenderJson(response.GetRawResponse(), settings, cts.Token);
     }

--- a/src/dotnet-openai/Vectors/ListCommand.cs
+++ b/src/dotnet-openai/Vectors/ListCommand.cs
@@ -11,7 +11,7 @@ namespace Devlooped.OpenAI.Vectors;
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("List vector stores")]
 [Service]
-class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<ListCommandSettings>
+public class ListCommand(OpenAIClient oai, IAnsiConsole console, VectorIdMapper mapper, CancellationTokenSource cts) : Command<ListCommandSettings>
 {
     public override int Execute(CommandContext context, ListCommandSettings settings)
     {
@@ -44,9 +44,14 @@ class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSourc
                 ctx.UpdateTarget(table);
                 foreach (var node in nodes["data"]!.AsArray().AsEnumerable().Where(x => x != null))
                 {
+                    var id = node!["id"]!.ToString();
+                    var name = node["name"]!.ToString();
+
+                    mapper.SetId(name, id);
+
                     table.AddRow(
-                        node!["id"]!.ToString(),
-                        node["name"]!.ToString(),
+                        id,
+                        name,
                         node["file_counts"]!["total"]!.ToString(),
                         int.Parse(node["usage_bytes"]!.ToString()).Bytes().Humanize(),
                         DateTimeOffset.FromUnixTimeSeconds(long.Parse(node["last_active_at"]!.ToString())).ToString("yyyy-MM-dd T HH:mm")

--- a/src/dotnet-openai/Vectors/StoreCommandSettings.cs
+++ b/src/dotnet-openai/Vectors/StoreCommandSettings.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Devlooped.OpenAI.Vectors;
+
+public class StoreCommandSettings(VectorIdMapper mapper) : JsonCommandSettings
+{
+    [Description("The ID or name of the vector store")]
+    [CommandArgument(0, "<STORE>")]
+    public required string Store { get; set; }
+
+    public override ValidationResult Validate()
+    {
+        Store = mapper.MapName(Store);
+        return base.Validate();
+    }
+}

--- a/src/dotnet-openai/Vectors/VectorIdMapper.cs
+++ b/src/dotnet-openai/Vectors/VectorIdMapper.cs
@@ -1,0 +1,74 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using DotNetConfig;
+using Microsoft.Extensions.DependencyInjection;
+using OpenAI;
+
+namespace Devlooped.OpenAI.Vectors;
+
+#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+[Service]
+public class VectorIdMapper(OpenAIClient oai)
+{
+    ConfigSection section = Config.Build(ConfigLevel.Global).GetSection(ThisAssembly.Project.ToolCommandName, "vectors");
+
+    public void RemoveId(string id)
+    {
+        foreach (var entry in Enumerate().Where(x => x.Value == id))
+            section = section.Unset(entry.Key, ConfigLevel.Global);
+    }
+
+    public void SetId(string name, string id)
+    {
+        var existing = Enumerate().Where(x => x.Value == id).Select(x => x.Key).FirstOrDefault();
+        if (existing != null && existing != name)
+            section = section.Unset(existing, ConfigLevel.Global);
+
+        if (!section.TryGetString(name, out var saved) || saved != id)
+            section = section.SetString(name, id, ConfigLevel.Global);
+    }
+
+    public bool TryGetId(string name, [NotNullWhen(true)] out string? id)
+    {
+        if (section.TryGetString(name, out id))
+            return true;
+
+        var stores = oai.GetVectorStoreClient().GetVectorStores();
+        foreach (var store in stores.Where(x => x.Name is not null))
+        {
+            section = section.SetString(store.Name, store.Id, ConfigLevel.Global);
+        }
+
+        if (section.TryGetString(name, out id))
+            return true;
+
+        return false;
+    }
+
+    public IEnumerable<KeyValuePair<string, string>> Enumerate()
+    {
+        foreach (var entry in Config.Build(ConfigLevel.Global).AsEnumerable()
+            .Where(x => x.Section == ThisAssembly.Project.ToolCommandName && x.Subsection == "vectors"))
+        {
+            yield return KeyValuePair.Create(entry.Variable, entry.GetString());
+        }
+    }
+}
+
+public static class VectorIdMapperExtensions
+{
+    /// <summary>
+    /// If the <paramref name="name"/> does not start with <c>vs_</c>, 
+    /// attempts to map it to a vector store ID using the <paramref name="mapper"/>, 
+    /// otherwise, returns the name as-is.
+    /// </summary>
+    public static string MapName(this VectorIdMapper mapper, string name)
+    {
+        if (name.StartsWith("vs_"))
+            return name;
+
+        if (mapper.TryGetId(name, out var id))
+            return id;
+
+        return name;
+    }
+}

--- a/src/dotnet-openai/Vectors/VectorsExtensions.cs
+++ b/src/dotnet-openai/Vectors/VectorsExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Humanizer;
+using OpenAI.VectorStores;
+using Spectre.Console;
+
+namespace Devlooped.OpenAI.Vectors;
+
+#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+static class VectorsExtensions
+{
+    public static Table AsTable(this VectorStore store)
+    {
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .AddColumn("[lime]ID[/]")
+            .AddColumn("[lime]Name[/]")
+            .AddColumn("[lime]Files[/]", x => x.RightAligned())
+            .AddColumn("[lime]Size[/]", x => x.RightAligned())
+            .AddColumn("[lime]Last Active[/]");
+
+        table.AddRow(
+            store.Id,
+            store.Name,
+            store.FileCounts.Total.ToString(),
+            store.UsageBytes.Bytes().Humanize(),
+            store.LastActiveAt?.ToString("yyyy-MM-dd T HH:mm") ?? ""
+        );
+
+        return table;
+    }
+}

--- a/src/dotnet-openai/dotnet-openai.csproj
+++ b/src/dotnet-openai/dotnet-openai.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.Extensions.DependencyInjection" Version="42.42.449-main" PrivateAssets="all" />
+    <PackageReference Include="Devlooped.Extensions.DependencyInjection" Version="2.1.0-rc.4" PrivateAssets="all" />
     <PackageReference Include="Devlooped.JQ" Version="1.7.1.8" />
     <PackageReference Include="Devlooped.Sponsors.Commands" Version="42.42.1585-main" />
     <PackageReference Include="DotNetConfig" Version="1.2.0" />
@@ -98,7 +98,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="RenderHelp" AfterTargets="Build" Condition="$(DesignTimeBuild) != 'true' and '$(OS)' == 'Windows_NT'">
+  <Target Name="RenderHelp" AfterTargets="Build" Condition="'' != '' and $(DesignTimeBuild) != 'true' and '$(OS)' == 'Windows_NT'">
     <PropertyGroup>
       <Cli>$(TargetDir)$(TargetName).exe</Cli>
       <HelpCommand>"$(Cli)" --help --unattended</HelpCommand>
@@ -117,7 +117,7 @@
     <WriteLinesToFile Lines="```" Overwrite="false" Encoding="UTF-8" File="Docs/help.md" />
   </Target>
 
-  <Target Name="RenderCommandHelp" AfterTargets="Build" Inputs="@(CommandHelp)" Outputs="|%(CommandHelp.Identity)|" Condition="$(DesignTimeBuild) != 'true' and '$(OS)' == 'Windows_NT'">
+  <Target Name="RenderCommandHelp" AfterTargets="Build" Inputs="@(CommandHelp)" Outputs="|%(CommandHelp.Identity)|" Condition="'' != '' and $(DesignTimeBuild) != 'true' and '$(OS)' == 'Windows_NT'">
     <PropertyGroup>
       <CommandHelp>%(CommandHelp.Identity)</CommandHelp>
       <Cli>$(TargetDir)$(TargetName).exe</Cli>


### PR DESCRIPTION
- Made commands public so we can invoke them from tests
- Remove confusing ICommandApp registration since it breaks assumptions about components lifetime
- Switch from IServiceProvider to ITypeRegistrar (native CLI abstraction)
- Name sure when new registrations are performed, to reset the service provider (the CLI app does this when running from args)
- Add vector tests
- Add semantic search comprehensive test (locally run for now only).