### PR TITLE
Fix DI for sponsor commands, refactor a bit

### DIFF
--- a/src/dotnet-openai/Sponsors/SponsorsAppExtensions.cs
+++ b/src/dotnet-openai/Sponsors/SponsorsAppExtensions.cs
@@ -23,60 +23,17 @@ static class SponsorsAppExtensions
         return app;
     }
 
-    static bool ShouldRunWelcome(ICommandApp app, Config config, ToSSettings settings)
+    public static bool ShouldRunWelcome(this CommandContext context, Config config, ToSSettings settings)
     {
         // If we don't have ToS acceptance, we don't run any command other than welcome.
         var tos = config.TryGetBoolean("sponsorlink", "tos", out var completed) && completed;
         if (!tos && settings.ToS == true)
         {
             // Implicit acceptance on first run of another tool, like `sponsor sync --tos`
-            app.Run(["sponsor", "config", ToSSettings.ToSOption, "--quiet"]);
+            new ConfigCommand(config).Execute(context, new ConfigCommand.ConfigSettings { ToS = true, Quiet = true });
             return false;
         }
 
         return tos == false;
-    }
-
-    [Description("Validates and displays the sponsor manifest for [lime]devlooped[/], if present")]
-    class DevloopedViewCommand(ICommandApp app, Config config, IHttpClientFactory http) : ViewCommand<DevloopedViewCommand.DevloopedViewSettings>(http)
-    {
-        public class DevloopedViewSettings : ViewSettings, ISponsorableSettings
-        {
-            public string[]? Sponsorable { get; set; } = ["devlooped"];
-        }
-
-        public override async Task<int> ExecuteAsync(CommandContext context, DevloopedViewSettings settings)
-        {
-            if (ShouldRunWelcome(app, config, settings))
-            {
-                if (await app.RunAsync(["sponsor", "welcome"]) is var result && result != 0)
-                    return result;
-            }
-
-            settings.Sponsorable = ["devlooped"];
-            return await base.ExecuteAsync(context, settings);
-        }
-    }
-
-    [Description("Synchronizes the sponsorship manifest for [lime]devlooped[/]")]
-    public class DevloopedSyncCommand(ICommandApp app, Config config, IGraphQueryClient client, IGitHubAppAuthenticator authenticator, IHttpClientFactory httpFactory)
-        : SyncCommand<DevloopedSyncCommand.DevloopedSyncSettings>(config, client, authenticator, httpFactory)
-    {
-        public class DevloopedSyncSettings : SyncSettings, ISponsorableSettings
-        {
-            public string[]? Sponsorable { get; set; } = ["devlooped"];
-        }
-
-        public override async Task<int> ExecuteAsync(CommandContext context, DevloopedSyncSettings settings)
-        {
-            if (ShouldRunWelcome(app, config, settings))
-            {
-                if (await app.RunAsync(["sponsor", "welcome"]) is var result && result != 0)
-                    return result;
-            }
-
-            settings.Sponsorable = ["devlooped"];
-            return await base.ExecuteAsync(context, settings);
-        }
     }
 }

--- a/src/dotnet-openai/Sponsors/SyncCommand.cs
+++ b/src/dotnet-openai/Sponsors/SyncCommand.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+using Devlooped.Sponsors;
+using DotNetConfig;
+using Spectre.Console.Cli;
+
+namespace Devlooped.OpenAI.Sponsors;
+
+[Description("Synchronizes your sponsorship manifest for [lime]devlooped[/]")]
+class DevloopedSyncCommand(Config config, IGraphQueryClient client, IGitHubAppAuthenticator authenticator, IHttpClientFactory httpFactory)
+    : SyncCommand<DevloopedSyncCommand.DevloopedSyncSettings>(config, client, authenticator, httpFactory)
+{
+    public class DevloopedSyncSettings : SyncSettings, ISponsorableSettings
+    {
+        public string[]? Sponsorable { get; set; } = ["devlooped"];
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, DevloopedSyncSettings settings)
+    {
+        if (context.ShouldRunWelcome(config, settings))
+        {
+            if (new WelcomeCommand(config).Execute(context, new WelcomeCommand.WelcomeSettings { ToS = settings.ToS }) is var result && result != 0)
+                return result;
+        }
+
+        settings.Sponsorable = ["devlooped"];
+        return await base.ExecuteAsync(context, settings);
+    }
+}

--- a/src/dotnet-openai/Sponsors/ViewCommand.cs
+++ b/src/dotnet-openai/Sponsors/ViewCommand.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel;
+using Devlooped.Sponsors;
+using DotNetConfig;
+using Spectre.Console.Cli;
+
+namespace Devlooped.OpenAI.Sponsors;
+
+[Description("Validates and displays your sponsor manifest for [lime]devlooped[/], if present")]
+class DevloopedViewCommand(Config config, IHttpClientFactory http) : ViewCommand<DevloopedViewCommand.DevloopedViewSettings>(http)
+{
+    public class DevloopedViewSettings : ViewSettings, ISponsorableSettings
+    {
+        public string[]? Sponsorable { get; set; } = ["devlooped"];
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, DevloopedViewSettings settings)
+    {
+        if (context.ShouldRunWelcome(config, settings))
+        {
+            if (new WelcomeCommand(config).Execute(context, new WelcomeCommand.WelcomeSettings { ToS = settings.ToS }) is var result && result != 0)
+                return result;
+        }
+
+        settings.Sponsorable = ["devlooped"];
+        return await base.ExecuteAsync(context, settings);
+    }
+}


### PR DESCRIPTION
The existing commands were not resolving anymore since we removed the ICommandApp from the DI container. This is because the lifetime of services gets all screwed up if you use Run() on the app more than once. So we instead execute the relevant commands directly.