### PR TITLE
Don't render empty tables

### DIFF
--- a/src/dotnet-openai/File/ListCommand.cs
+++ b/src/dotnet-openai/File/ListCommand.cs
@@ -71,7 +71,8 @@ public class ListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTok
                 }
             });
 
-        console.Write(table);
+        if (table.Rows.Count > 0)
+            console.Write(table);
 
         return 0;
     }

--- a/src/dotnet-openai/Vectors/FileListCommand.cs
+++ b/src/dotnet-openai/Vectors/FileListCommand.cs
@@ -65,7 +65,8 @@ public class FileListCommand(OpenAIClient oai, IAnsiConsole console, Cancellatio
                 }
             });
 
-        console.Write(table);
+        if (table.Rows.Count > 0)
+            console.Write(table);
 
         return 0;
     }

--- a/src/dotnet-openai/Vectors/ListCommand.cs
+++ b/src/dotnet-openai/Vectors/ListCommand.cs
@@ -59,7 +59,8 @@ public class ListCommand(OpenAIClient oai, IAnsiConsole console, VectorIdMapper 
                 }
             });
 
-        console.Write(table);
+        if (table.Rows.Count > 0)
+            console.Write(table);
 
         return 0;
     }


### PR DESCRIPTION
When listing items, if none is found, don't render anything. Empty tables look like a bug :)