### PR TITLE
Allow adding or modifying file attributes in a vector store

### DIFF
--- a/src/dotnet-openai/Docs/vector-file.md
+++ b/src/dotnet-openai/Docs/vector-file.md
@@ -14,8 +14,9 @@ OPTIONS:
     -h, --help    Prints help information
 
 COMMANDS:
-    add <STORE> <FILE_ID>       Add file to vector store               
-    delete <STORE> <FILE_ID>    Remove file from vector store          
-    list <STORE>                List files associated with vector store
-    view <STORE> <FILE_ID>      View file association to a vector store
+    add <STORE> <FILE_ID>       Add file to vector store                     
+    delete <STORE> <FILE_ID>    Remove file from vector store                
+    list <STORE>                List files associated with vector store      
+    modify <STORE> <FILE_ID>    Add or modify file attributes in vector store
+    view <STORE> <FILE_ID>      View file association to a vector store      
 ```

--- a/src/dotnet-openai/Vectors/FileListCommand.cs
+++ b/src/dotnet-openai/Vectors/FileListCommand.cs
@@ -12,14 +12,14 @@ namespace Devlooped.OpenAI.Vectors;
 #pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 [Description("List files associated with vector store")]
 [Service]
-public class FileListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileListCommand.Settings>
+public class FileListCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : Command<FileListCommand.FileListSettings>
 {
     static readonly JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web)
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
     };
 
-    public override int Execute(CommandContext context, Settings settings)
+    public override int Execute(CommandContext context, FileListSettings settings)
     {
         var options = new VectorStoreFileAssociationCollectionOptions
         {
@@ -71,7 +71,7 @@ public class FileListCommand(OpenAIClient oai, IAnsiConsole console, Cancellatio
         return 0;
     }
 
-    public class Settings(VectorIdMapper mapper) : ListCommandSettings
+    public class FileListSettings(VectorIdMapper mapper) : ListCommandSettings
     {
         [Description("The ID or name of the vector store")]
         [CommandArgument(0, "<STORE>")]

--- a/src/dotnet-openai/Vectors/FileModifyCommand.cs
+++ b/src/dotnet-openai/Vectors/FileModifyCommand.cs
@@ -1,0 +1,53 @@
+﻿using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
+using OpenAI;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Devlooped.OpenAI.Vectors;
+
+#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+[Description("Add or modify file attributes in vector store")]
+[Service]
+public class FileModifyCommand(OpenAIClient oai, IAnsiConsole console, CancellationTokenSource cts) : FileAddCommand(oai, console, cts)
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, FileAddSettings settings)
+    {
+        // We can't really modify the existing file association, so we remove and re-add it, 
+        // preserving any existing attributes.
+        var vectors = oai.GetVectorStoreClient();
+        var response = await vectors.GetFileAssociationAsync(settings.Store, settings.FileId, cts.Token);
+        var attributes = new Dictionary<string, object>();
+
+        foreach (var existing in response.Value.Attributes)
+        {
+            var value = existing.Value.ToString().Trim('\"');
+            if (double.TryParse(value, out var number))
+                attributes[existing.Key] = number;
+            else if (bool.TryParse(value, out var boolean))
+                attributes[existing.Key] = boolean;
+            else
+                attributes[existing.Key] = value;
+        }
+
+        // New values override existing ones
+        foreach (var item in settings.Attributes)
+        {
+            var parts = item.Split(['='], 2);
+            if (parts.Length == 2)
+            {
+                var key = parts[0].Trim();
+                var value = parts[1].Trim();
+                if (double.TryParse(value, out var number))
+                    attributes[key] = number;
+                else if (bool.TryParse(value, out var boolean))
+                    attributes[key] = boolean;
+                else
+                    attributes[key] = value;
+            }
+        }
+
+        await vectors.RemoveFileFromStoreAsync(settings.Store, settings.FileId, cts.Token);
+        return await AddAsync(settings, attributes);
+    }
+}

--- a/src/dotnet-openai/Vectors/VectorsAppExtensions.cs
+++ b/src/dotnet-openai/Vectors/VectorsAppExtensions.cs
@@ -30,6 +30,7 @@ static class VectorsAppExtensions
                         .WithExample("file add mystore nypop.md -a region=us -a popularity=90");
                     file.AddCommand<FileRemoveCommand>("delete");
                     file.AddCommand<FileListCommand>("list");
+                    file.AddCommand<FileModifyCommand>("modify");
                     file.AddCommand<FileViewCommand>("view");
                 });
             });


### PR DESCRIPTION
Preserve existing attributes and copy over to the re-added file. We cannot update in-place because this isn't supported by OpenAI retrieval API. But from experimentation, when done quickly, the file indexing is preserved.