### PR TITLE
Improve performance with --skip --take on large lists

### DIFF
--- a/src/Tests/RangeTests.cs
+++ b/src/Tests/RangeTests.cs
@@ -49,6 +49,14 @@ public class RangeTests
         var ex = await Assert.ThrowsAsync<CompilationErrorException>(async () => await ApplyRangeAsync(list, rangeString));
     }
 
+    [Fact]
+    public async Task CanEvaluateRange()
+    {
+        var range = await CSharpScript.EvaluateAsync<Range>("..^5");
+
+        Assert.NotNull(range);
+    }
+
     public static async Task<List<T>> ApplyRangeAsync<T>(List<T> collection, string rangeString)
     {
         var script = CSharpScript.Create<List<T>>(

--- a/src/dotnet-openai/ListCommandSettings.cs
+++ b/src/dotnet-openai/ListCommandSettings.cs
@@ -73,6 +73,17 @@ public class ListCommandSettings : JsonCommandSettings
 
             nodes.AddRange(((JsonArray)data).AsEnumerable());
             first = false;
+
+            // See if we can apply the filter here without further loading.
+            if (!Range.IsSet &&
+                (!Skip.IsSet || Skip.Value <= nodes.Count) &&
+                Take.IsSet && (Take.Value + Skip.Value <= nodes.Count))
+            {
+                // We can apply the filter here without further loading.
+                nodes = [.. nodes.Skip(Skip.Value).Take(Take.Value)];
+                result["data"] = new JsonArray([.. nodes.Where(x => x != null).Select(x => x!.DeepClone())]);
+                return result;
+            }
         }
 
         nodes = ApplyFilters(nodes);


### PR DESCRIPTION
Rather than reading all entries before applying the filters, we can be smarter about --skip and --take and exit the enumeration as soon as we have enough items.

Doing the same for Range is tricky since it can represent a lot of cases, so for now we keep full evaluation for range expressions.